### PR TITLE
Style and clarity edits and adds new default execution timeout

### DIFF
--- a/docs/serverless/endpoints/send-requests.md
+++ b/docs/serverless/endpoints/send-requests.md
@@ -52,9 +52,11 @@ This default behavior keeps a hanging request from draining your account credits
 
 To customize the management of job lifecycles and resource consumption, the following policies can be configured:
 
-- **Execution Timeout**: Specifies the maximum duration that a job can run before it's automatically terminated. This limit helps prevent jobs from running indefinitely and consuming resources. The default value is 600000 milliseconds (10 minutes). You can overwrite the default by specifying `executionTimeout` in the job input.
+- **Execution Timeout**: Specifies the maximum duration that a job can run before it's automatically terminated. This limit helps prevent jobs from running indefinitely and consuming resources. The default value is 600000 milliseconds (10 minutes). You can overwrite the value for a request by specifying `executionTimeout` in the job input.
 
 :::note
+
+Changing the **Execution Timeout** value through the web UI sets the value for all requests to an endpoint. You can still overwrite the value for individual requests with `executionTimeout` in the job input.
 
 :::
 

--- a/docs/serverless/endpoints/send-requests.md
+++ b/docs/serverless/endpoints/send-requests.md
@@ -10,7 +10,7 @@ Let's start by constructing our request body to send to the endpoint.
 
 ## JSON Request Body
 
-You can make requests to your endpoint with JSON. Your request must include an `input` key containing a dictionary of inputs required for the job. For example, if your handler requires an input prompt, you might send in something like this:
+You can make requests to your endpoint with JSON. Your request must include a JSON object containing an `input` key. For example, if your handler requires an input prompt, you might send in something like this:
 
 ```json
 {
@@ -42,7 +42,7 @@ To see notifications for completed jobs, pass a URL in the top level of the requ
 
 Your webhook endpoint should respond with a `200` status to acknowledge the successful call. If the call is not successful, the request waits 10 seconds and sends the call again up to two more times.
 
-A POST request goes to your URL when the job is complete. This request contains the same information as fetching the results from the `/status/{job_id}` endpoint.
+A `POST` request goes to your URL when the job is complete. This request contains the same information as fetching the results from the `/status/{job_id}` endpoint.
 
 ### Execution Policies
 
@@ -52,7 +52,12 @@ This default behavior keeps a hanging request from draining your account credits
 
 To customize the management of job lifecycles and resource consumption, the following policies can be configured:
 
-- **Execution Timeout**: Specifies the maximum duration that a job can run before it's automatically terminated. This limit helps prevent jobs from running indefinitely and consuming resources. The default value is 600 seconds (10 minutes). You can overwrite the default by specifying `executionTimeout` in the job input.
+- **Execution Timeout**: Specifies the maximum duration that a job can run before it's automatically terminated. This limit helps prevent jobs from running indefinitely and consuming resources. The default value is 600000 milliseconds (10 minutes). You can overwrite the default by specifying `executionTimeout` in the job input.
+
+:::note
+
+:::
+
 - **Low Priority**: When true, the job does not trigger scaling up resources to execute. Instead, it executes when there are no pending higher priority jobs in the queue. Use this option for tasks that are not time-sensitive. 
 - **TTL (Time-to-Live)**: Defines the maximum time a job can remain in the queue before it's automatically terminated. This parameter ensures that jobs don't stay in the queue indefinitely.
 
@@ -60,7 +65,7 @@ To customize the management of job lifecycles and resource consumption, the foll
 {
   "input": {},
   "policy": {
-    "executionTimeout": int, // Time in milliseconds. Must be greater than 5 seconds.
+    "executionTimeout": int, // Time in milliseconds. Must be greater than 5 seconds. Default is 10 minutes.
     "lowPriority": bool, // Sets the job's priority to low. Default behavior escalates to high under certain conditions.
     "ttl": int // Time in milliseconds. Must be greater than or equal to 10 seconds. Default is 24 hours. Maximum is one week.
   }

--- a/docs/serverless/endpoints/send-requests.md
+++ b/docs/serverless/endpoints/send-requests.md
@@ -4,12 +4,13 @@ description: "The method in which jobs are submitted and returned."
 sidebar_position: 4
 ---
 
-With a successful custom endpoint deployed, you are nearly ready to make a job request.
-Let's start by constructing our request body that will be submitted.
+Before sending a job request, ensure you have deployed your custom endpoint. 
+
+Let's start by constructing our request body to send to the endpoint.
 
 ## JSON Request Body
 
-Requests to your endpoint must be made via a JSON formatted request; at a minimum, it will need to have an `input` key containing a dictionary of inputs required to complete your job request. For example, if your handler required an input prompt, you might send in something like this:
+You can make requests to your endpoint with JSON. Your request must include an `input` key containing a dictionary of inputs required for the job. For example, if your handler requires an input prompt, you might send in something like this:
 
 ```json
 {
@@ -19,17 +20,18 @@ Requests to your endpoint must be made via a JSON formatted request; at a minimu
 }
 ```
 
----
-
 ## Optional Inputs
 
-Along with an input key, other top-level inputs can also be included and offer different functions. If a key is passed in at the top level and not included here, it will be discarded and unavailable to your handler.
+Along with an input key, you can include other top-level inputs to access different functions. If a key is passed in at the top level and not included in the body of your request, it will be discarded and unavailable to your handler.
 
-> 👍 These optional inputs are available to all endpoints regardless of the worker.
+The following optional inputs are available to all endpoints regardless of the worker.
+* Webhooks
+* Execution policies
+* S3-compatible storage
 
-### ⚓ | Webhook
+### Webhooks
 
-To be notified of completed jobs, a URL can be passed within the top level of the request like so:
+To see notifications for completed jobs, pass a URL in the top level of the request:
 
 ```json
 {
@@ -38,18 +40,20 @@ To be notified of completed jobs, a URL can be passed within the top level of th
 }
 ```
 
-Your webhook endpoint should respond with a 200 status to acknowledge the successful call. If not received, the webhook will be attempted up to 2 times after a 10-second timeout.
+Your webhook endpoint should respond with a `200` status to acknowledge the successful call. If the call is not successful, the request waits 10 seconds and sends the call again up to two more times.
 
-A POST request will be sent to your URL when the job is complete. This request will contain the same information you would receive if you fetched the results from the `/status/{job_id}` endpoint.
+A POST request goes to your URL when the job is complete. This request contains the same information as fetching the results from the `/status/{job_id}` endpoint.
 
-### 📜 | Execution Policy
+### Execution Policies
 
-By default, if a job remains `IN_PROGRESS` for longer than 24 hours without completion, it's automatically terminated.
-This default behavior ensures that resources aren't indefinitely consumed by jobs that are unable to complete.
+By default, if a job remains `IN_PROGRESS` for longer than 10 minutes without completion, it's automatically terminated.
+
+This default behavior keeps a hanging request from draining your account credits.
+
 To customize the management of job lifecycles and resource consumption, the following policies can be configured:
 
-- **Execution Timeout**: Specifies the maximum duration a job can run before it's automatically terminated. This limit helps prevent jobs from running indefinitely and consuming resources unnecessarily.
-- **Low Priority**: When set, the job is marked as low priority. This option is ideal for non-time-sensitive tasks that don't require immediate execution. Low priority jobs won't trigger a scale-up of resources and only execute when higher priority jobs aren't pending. When the queue is empty, low priority jobs are executed.
+- **Execution Timeout**: Specifies the maximum duration that a job can run before it's automatically terminated. This limit helps prevent jobs from running indefinitely and consuming resources. The default value is 600 seconds (10 minutes). You can overwrite the default by specifying `executionTimeout` in the job input.
+- **Low Priority**: When true, the job does not trigger scaling up resources to execute. Instead, it executes when there are no pending higher priority jobs in the queue. Use this option for tasks that are not time-sensitive. 
 - **TTL (Time-to-Live)**: Defines the maximum time a job can remain in the queue before it's automatically terminated. This parameter ensures that jobs don't stay in the queue indefinitely.
 
 ```json
@@ -63,11 +67,11 @@ To customize the management of job lifecycles and resource consumption, the foll
 }
 ```
 
-By configuring both the execution timeout and TTL policies, you can have more control over job execution and system resource management, ensuring efficient operation and preventing resource wastage.
+By configuring the execution timeout, priority, and TTL policies, you have more control over job execution and efficient system resource management.
 
-### 💾 | S3-Compatible Storage
+### S3-Compatible Storage
 
-The credentials for S3-compatible object storage can be passed in with the request as follows:
+Pass in the credentials for S3-compatible object storage as follows:
 
 ```json
 {
@@ -81,6 +85,10 @@ The credentials for S3-compatible object storage can be passed in with the reque
 }
 ```
 
-The configuration is only passed onto the worker; it will not be returned as part of the job request output.
+The configuration only passes to the worker. It is not returned as part of the job request output.
 
-_Note: The serverless worker will need to contain the logic/functionality that allows it to make sure of this input. If you build a custom endpoint and request s3Config in the input, your worker is ultimately responsible for using the information passed in to upload the output._
+:::note
+
+The serverless worker must contain logic that allows it to use this input. If you build a custom endpoint and request s3Config in the job input, your worker is ultimately responsible for using the information passed in to upload the output. 
+
+:::


### PR DESCRIPTION
Did the unit for execution timeout change from milliseconds to seconds? I see seconds in the interface, but the existing docs specified milliseconds.