### PR TITLE
Rework of the vLLM Worker Docs

### DIFF
--- a/docs/serverless/workers/vllm/_category_.json
+++ b/docs/serverless/workers/vllm/_category_.json
@@ -3,6 +3,6 @@
   "position": 2,
   "link": {
     "type": "generated-index",
-    "description": "Run any LLM model with RunPod's vLLM Worker."
+    "description": "Deploy blazingly fast OpenAI-compatible serverless endpoints for any LLM."
   }
 }

--- a/docs/serverless/workers/vllm/overview.md
+++ b/docs/serverless/workers/vllm/overview.md
@@ -11,12 +11,13 @@ RunPod's vLLM Serverless Endpoint Worker are a highly optimized solution for lev
 
 ## Key features
 
-- **Ease of Use**: Deploy any model using the `runpod/worker-vllm:latest` Docker image without the hassle of building custom Docker images, uploading heavy models, or waiting for lengthy downloads.
-- **OpenAI Compatibility**: Seamlessly integrate with OpenAI's API by adjusting only a few lines of code, supporting routes like Chat Completions, Completions, and Models, both in streaming and non-streaming modes.
-- **Dynamic Batch Size**: Experience rapid time-to-first-token responses with dynamic batch sizes, balancing performance and efficiency throughout your request.
-- **Extensive Model Support**: From Gemma and DeepSeek MoE to OLMo, along with FP8 KV Cache support and Multi-LoRA readiness, expand your capabilities with a wide array of models and settings.
-- **Customization**: Tailor your deployment with custom chat templates, tokenization settings, and system configurations to fit your specific needs.
-- **Efficiency**: Utilize environment variables to fine-tune LLM settings, tokenizer options, system configurations, and more, ensuring optimal performance and resource utilization.
+- **Ease of Use**: Deploy any LLM using the pre-built Docker image without the hassle of building custom Docker images yourself, uploading heavy models, or waiting for lengthy downloads. 
+- **OpenAI Compatibility**: Seamlessly integrate with OpenAI's API by changing 2 lines of code, supporting Chat Completions, Completions, and Models, with both streaming and non-streaming.
+- **Dynamic Batch Size**: Experience the rapid time-to-first-token high of no batching combined with the high throughput of larger batch sizes. (Related to batching tokens when streaming output)
+- **Extensive Model Support**: Deploy almost any LLM from Hugging Face, including your own.
+- **Customization**: Have full control over the configuration of every aspect of your deployment, from the model settings, to tokenizer options, to system configurations, and much more, all done through environment variables.
+- **Speed**: Experience the speed of the vLLM Engine.
+- **Serverless Scalability and Cost-Effectiveness**: Scale your deployment to handle any number of requests and only pay for active usage.
 
 ## Compatible models
 


### PR DESCRIPTION
The current vLLM worker docs are largely outdated(pointing to nonexistent images) and inaccurate(e.g., they mention vLLM Worker supporting Multi-Lora in the overview, despite that actual Worker vLLM docs stating at the very top that it is not supported). 
Given this is our main inference offering, we need to ensure the correctness of the documentation and that we are highlighting relevant benefits. I only changed a few lines in my commit to get this started, but this really needs to be a complete overwork that should follow the vLLM worker docs closely.