### PR TITLE
fix: changed backticks to single quotes in docker command examples

### DIFF
--- a/docs/pods/templates/overview.md
+++ b/docs/pods/templates/overview.md
@@ -27,11 +27,11 @@ If you want better control over what gets done at pod start, you can modify the 
 For example, the default docker command is:
 
 ```bash
-bash -c `/start.sh`
+bash -c '/start.sh'
 ```
 
 If you wanted to run something before `start.sh`, you can put an extra command there.
 
 ```bash
-bash -c `apt update && apt install vim -y && /start.sh`
+bash -c 'apt update && apt install vim -y && /start.sh'
 ```


### PR DESCRIPTION
had a typo in the docker commands examples, using backticks results in errors when starting a pod. Example works when using single quotes.