### PR TITLE
DOCS-269 Update Job Operations docs

### DIFF
--- a/docs/api/api-endpoints.md
+++ b/docs/api/api-endpoints.md
@@ -129,11 +129,12 @@ Note how you don't get the images directly in the output. The output contains th
 
 You've successfully generated your first images with our Stable Diffusion API!
 
-### Rate Limit
+### Rate Limits
 
-Rate limits are enforced on a per-user basis.
-If you exceed the rate limit, you will receive a `429` error code.
+Rate limits are enforced per-user basis. 
+Exceeding limits returns a `429` error.
 
-`/run` - 1000 requests every 10s.
+`/run` - 1000 requests/10s, max 200 concurrent
+`/runsync` - 2000 requests/10s, max 400 concurrent
 
-`/runsync` - 2000 requests every 10s.
+For more information, see [Job operations](/serverless/references/operations).

--- a/docs/serverless/endpoints/job-operations.md
+++ b/docs/serverless/endpoints/job-operations.md
@@ -266,33 +266,29 @@ The maximum size for a payload that can be sent using yield to stream results is
 
 ## Rate Limits
 
+RunPod's Endpoints facilitate submitting jobs and retrieving outputs. 
+Access these endpoints at: `https://api.runpod.ai/v2/{endpoint_id}/{operation}`
+
 - `/run`
+  - 1000 requests per 10 seconds, 200 concurrent
 
-  - Default: 1000 requests per 10 seconds.
-  - For every running worker: Limit increases by 200 requests per 10 seconds.
+- `/runsync`  
+  - 2000 requests per 10 seconds, 400 concurrent
 
-- `/runsync`
-
-  - Default: 2000 requests per 10 seconds.
-  - For every running worker: Limit increases by 400 requests per 10 seconds.
-
-- `/status`
-
-  - Default: 2000 requests per 10 seconds.
-  - For every running worker: Limit increases by 400 requests per 10 seconds.
+- `/status`, `/status-sync`, `/stream`
+  - 2000 requests per 10 seconds, 400 concurrent
 
 - `/cancel`
-
-  - Default: 100 requests per 10 seconds.
-  - For every running worker: Limit increases by 20 requests per 10 seconds.
+  - 100 requests per 10 seconds, 20 concurrent
 
 - `/purge-queue`
+  - 2 requests per 10 seconds
 
-  - Limit: 2 requests per 10 seconds (no scaling with workers).
+- `/openai/*`
+  - 2000 requests per 10 seconds, 400 concurrent
 
-- `/openai`
-  - Default: 2000 requests per 10 seconds.
-  - For every running worker: Limit increases by 400 requests per 10 seconds.
+- `/requests`
+  - 10 requests per 10 seconds, 2 concurrent
 
 :::note
 

--- a/docs/serverless/references/operations.md
+++ b/docs/serverless/references/operations.md
@@ -4,26 +4,61 @@ description: "RunPod's Endpoints enable job submission and output retrieval, usi
 sidebar_position: 2
 ---
 
-RunPod's Endpoints facilitate submitting jobs and retrieving outputs.
+RunPod's Endpoints facilitate submitting jobs and retrieving outputs. Access these endpoints at: `https://api.runpod.ai/v2/{endpoint_id}/{operation}`
 
-To use these Endpoints, you will need to have your Endpoint Id.
-The constructed URL will start with `https://api.runpod.ai/v2/{endpoint_id}/{operation}` followed by an operation.
 
-Operations available to all users are:
+### /run
 
-- `/run`: Asynchronous endpoint for submitting jobs. Returns a unique Job ID.
-  - Payload capacity: 10 MB
-  - Rate limit: 1000 per second
-  - Job availability: Job results are accessible for 30 minutes after completion
-- `/runsync`: Synchronous endpoint for shorter running jobs, returning immediate results.
-  - Payload capacity: 20 MB
-  - Rate limit: 2000 requests every 10 seconds
-  - Job availability: Job results are accessible for 60 seconds after completion
-- `/stream/{job_id}`: For streaming results from generator-type handlers.
-- `/status/{job_id}`: To check the job status and retrieve outputs upon completion.
-- `/cancel/{job_id}`: To cancel a job prematurely.
-- `/health`: Provides worker statistics and endpoint health.
-  - Only accepts `GET` methods
-- `/purge-queue`: Clears all queued jobs, it will not cancel jobs in progress.
+- **Method**: `POST`
+- **Description**: Asynchronous endpoint for submitting jobs
+- **Returns**: Unique Job ID
+- **Payload Limit**: 10 MB
+- **Rate Limit**: 1000 requests per 10 seconds, 200 concurrent
+- **Job Availability**: 30 minutes after completion
+
+### /runsync
+
+- **Method**: `POST`
+- **Description**: Synchronous endpoint for shorter running jobs
+- **Returns**: Immediate results
+- **Payload Limit**: 20 MB
+- **Rate Limit**: 2000 requests per 10 seconds, 400 concurrent
+- **Job Availability**: 60 seconds after completion
+
+### Queue Limits
+
+- Requests will receive a `429 (Too Many Requests)` status if:
+  - Queue size exceeds 50 jobs AND
+  - Queue size exceeds endpoint.WorkersMax * 500
+
+### Status and Stream Operations
+
+All status and stream operations share a rate limit of 2000 requests per 10 seconds, 400 concurrent:
+
+- `/status/{job_id}` - Check job status and retrieve outputs
+  - Methods: `GET` | `POST`
+- `/status-sync/{job_id}` - Synchronous status check
+  - Methods: `GET` | `POST`
+- `/stream/{job_id}` - Stream results from generator-type handlers
+  - Methods: `GET` | `POST`
+
+### Additional Operations
+
+- `/cancel/{job_id}`
+  - **Method**: `POST`
+  - **Rate Limit**: 100 requests per 10 seconds, 20 concurrent
+  
+- `/purge-queue`
+  - **Method**: `POST`
+  - **Description**: Clears all queued jobs (does not affect running jobs)
+  - **Rate Limit**: 2 requests per 10 seconds
+  
+- `/health`
+  - **Method**: `GET`
+  - **Description**: Provides worker statistics and endpoint health
+
+- `/requests`
+  - **Method**: `GET`
+  - **Rate Limit**: 10 requests per 10 seconds, 2 concurrent
 
 To see how to run these Endpoint Operations, see [Invoke a Job](/serverless/endpoints/job-operations).


### PR DESCRIPTION
fixes https://linear.app/runpod/issue/DOCS-269/clarify-serverless-job-rate-limits-and-queue-size-limits