### PR TITLE
Update Template/Docker Image being called to reference the new migrated repo location

### DIFF
--- a/docs/tutorials/pods/fine-tune-llm-axolotl.md
+++ b/docs/tutorials/pods/fine-tune-llm-axolotl.md
@@ -23,7 +23,7 @@ Because of this, we recommend fine-tuning using RunPod's GPUs.
 
 To do this, you'll need to create a Pod, specify a container, then you can begin training.
 A Pod is an instance on a GPU or multiple GPUs that you can use to run your training job.
-You also specify a Docker image like `winglian/axolotl-cloud:main-latest` that you want installed on your Pod.
+You also specify a Docker image like `axolotlai/axolotl-cloud:main-latest` that you want installed on your Pod.
 
 1. Login to [RunPod](https://www.runpod.io/console/console/home) and deploy your Pod.
    1. Select **Deploy**.

--- a/docs/tutorials/pods/fine-tune-llm-axolotl.md
+++ b/docs/tutorials/pods/fine-tune-llm-axolotl.md
@@ -28,7 +28,7 @@ You also specify a Docker image like `winglian/axolotl-cloud:main-latest` that y
 1. Login to [RunPod](https://www.runpod.io/console/console/home) and deploy your Pod.
    1. Select **Deploy**.
    2. Select a GPU instance.
-   3. Specify the `winglian/axolotl-cloud:main-latest` image as your Template image.
+   3. Specify the `axolotlai/axolotl-cloud:main-latest` image as your Template image.
    4. Select your GPU count.
    5. Select **Deploy**.
 


### PR DESCRIPTION
Winglian no longer maintains or owns this project and has moved it under axolotl.
https://github.com/winglian/axolotl

The new docker image and RunPod Template names to be called are 
**axolotlai/axolotl-cloud:main-latest**