### PR TITLE
Fix input payloads to only contain prompts

### DIFF
--- a/docs/sdks/python/endpoints.md
+++ b/docs/sdks/python/endpoints.md
@@ -73,9 +73,7 @@ endpoint = runpod.Endpoint("YOUR_ENDPOINT_ID")
 try:
     run_request = endpoint.run_sync(
         {
-            "input": {
-                "prompt": "Hello, world!",
-            }
+            "prompt": "Hello, world!",
         },
         timeout=60,  # Timeout in seconds.
     )
@@ -108,7 +106,7 @@ import os
 
 runpod.api_key = os.getenv("RUNPOD_API_KEY")
 
-input_payload = {"input": {"prompt": "Hello, World!"}}
+input_payload = {"prompt": "Hello, World!"}
 
 try:
     endpoint = runpod.Endpoint("YOUR_ENDPOINT_ID")


### PR DESCRIPTION
Fix input payloads to only contain prompts, as expected by the called functions.
`run()` and `run_sync()` expect the data_input to directly contain the input values in a dict, and not be contained within an "input" dict.