### PR TITLE
fix: "Deploy w/ Slurm" link now links to Slurm docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 
 
 helpers/__pycache__/** */
+
+# Webstorm
+.idea/*

--- a/docs/instant-clusters/index.md
+++ b/docs/instant-clusters/index.md
@@ -26,7 +26,7 @@ Get started with Instant Clusters by following a step-by-step tutorial for your 
 
 - [Deploy an Instant Cluster with PyTorch](/instant-clusters/pytorch).
 - [Deploy an Instant Cluster with Axolotl](/instant-clusters/axolotl).
-- [Deploy an Instant Cluster with Slurm](/instant-clusters/axolotl).
+- [Deploy an Instant Cluster with Slurm](/instant-clusters/slurm).
 
 ## Use cases for Instant Clusters
 


### PR DESCRIPTION
The "Deploy an Instant Cluster with Slurm." link leads to the Axolotl docs, this just fixes that to link to the Slurm docs