### PR TITLE
Add related posts (i.e., Network volumes) for storage full troubleshooting

### DIFF
--- a/docs/references/troubleshooting/storage-full.md
+++ b/docs/references/troubleshooting/storage-full.md
@@ -79,6 +79,6 @@ rm -r /path/to/directory
 ```
 
 
-## Additional Storage
+## Additional storage
 
-If you need more than 20GB storage, Network volumes could be a choice. Please check [blog - Network volumes](https://blog.runpod.io/four-reasons-to-set-up-a/), and [docs - Network volumes](https://docs.runpod.io/pods/storage/create-network-volumes) for additional storage.
+If your Pod needs more than 20GB of storage, consider using a network volume. For more information, see [Create a network volume](/pods/storage/create-network-volumes), or refer to [this blog post](https://blog.runpod.io/four-reasons-to-set-up-a/).

--- a/docs/references/troubleshooting/storage-full.md
+++ b/docs/references/troubleshooting/storage-full.md
@@ -77,3 +77,8 @@ rm /path/to/file
 # To remove an entire directory and its contents, use the rm -r command:
 rm -r /path/to/directory
 ```
+
+
+## Additional Storage
+
+If you need more than 20GB storage, Network volumes could be a choice. Please check [blog - Network volumes](https://blog.runpod.io/four-reasons-to-set-up-a/), and [docs - Network volumes](https://docs.runpod.io/pods/storage/create-network-volumes) for additional storage.


### PR DESCRIPTION
This update links related blogs and docs for common troubleshooting, "storage full issue".

Because cleaning up is not optimal solution for users who want more than 20GB storage, related docs would lead them to Network Volumes directly.