### PR TITLE
Fix markup in pricing.mdx

### DIFF
--- a/serverless/pricing.mdx
+++ b/serverless/pricing.mdx
@@ -45,7 +45,7 @@ Billing starts when the system signals a worker to wake up and ends when the wor
 Your total Serverless costs include both compute time (GPU usage) and temporary storage:
 
 1. **Compute costs**: Charged per second based on the GPU type as shown in the pricing table above.
-2. **Storage costs**: The worker container volume incurs charges only while workers are running, calculated in 5-minute intervals. Even if your worker runs for less than 5 minutes, you'll be charged for the full 5-minute period. The storage cost is $0.000011574 per GB per 5 minutes (equivalent to approximately $0.10 per GB per month).
+2. **Storage costs**: The worker container volume incurs charges only while workers are running, calculated in 5-minute intervals. Even if your worker runs for less than 5 minutes, you'll be charged for the full 5-minute period. The storage cost is \$0.000011574 per GB per 5 minutes (equivalent to approximately \$0.10 per GB per month).
 
 If you have many workers continuously running with high storage costs, you can utilize [network volumes](/pods/storage/create-network-volumes) to reduce expenses. Network volumes allow you to share data efficiently across multiple workers, reduce per-worker storage requirements by centralizing common files, and maintain persistent storage separate from worker lifecycles.
 


### PR DESCRIPTION
Unescaped dollar signs causing problems: https://docs.runpod.io/serverless/pricing#compute-and-storage-costs