### PR TITLE
Add step for creating a network volume to s3-api.mdx

### DIFF
--- a/serverless/storage/s3-api.mdx
+++ b/serverless/storage/s3-api.mdx
@@ -17,8 +17,15 @@ Using the S3-compatible API to access your network volumes does not affect prici
 ## Setup and authentication
 
 <Steps>
-  <Step title="Create an S3 API key">
-    To use the S3-compatible API, you must generate a new key called an "S3 API key", separate from your Runpod API key.
+<Step title="Create a network volume">
+
+    Before you can use the S3-compatible API, you must [create a network volume](/serverless/storage/network-volumes). The volume must be located in a [supported datacenter](#datacenter-availability) for the S3-compatible API to work.
+
+</Step>
+
+<Step title="Create an S3 API key">
+
+    Next, you'll need to generate a new key called an "S3 API key" (this is separate from your Runpod API key).
 
     1. In the Runpod console, navigate to the [Settings page](https://www.runpod.io/console/user/settings).
     2. Expand the **S3 API Keys** section and select **Create an S3 API key**.
@@ -30,9 +37,11 @@ Using the S3-compatible API to access your network volumes does not affect prici
     For security, Runpod will show your secret access key only once, so you may wish to save it elsewhere (e.g., in your password manager, or in a GitHub secret). Treat your secret access key like a password and don't share it with anyone.
 
     </Warning>
+    
   </Step>
 
   <Step title="Configure AWS CLI">
+
     To use the S3-compatible API with your Runpod network volumes, you must configure your AWS CLI with the Runpod S3 API key you created.
 
     1.  If you haven't already, [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) on your local machine.
@@ -48,17 +57,6 @@ Using the S3-compatible API to access your network volumes does not affect prici
   </Step>
 </Steps>
 
-## Using the S3-compatible API
-
-You can use the S3-compatible API to interact with your Runpod network volumes using standard S3 tools:
-
-*   [AWS CLI commands](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/index.html).
-*   [The Boto3 Python library](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html).
-
-Core AWS CLI operations such as `ls`, `cp`, `mv`, `rm`, and `sync` function as expected.
-
-
-
 ## Datacenter availability
 
 The S3-compatible API is currently available for network volumes hosted in a limited number of datacenters.
@@ -71,6 +69,15 @@ Create a network volume in one of the following datacenters to use the S3-compat
 |-------------|--------------|
 | `EUR-IS-1` | `https://s3api-eur-is-1.runpod.io/` |
 | `EU-RO-1` | `https://s3api-eu-ro-1.runpod.io/` |
+
+## Using the S3-compatible API
+
+You can use the S3-compatible API to interact with your Runpod network volumes using standard S3 tools:
+
+*   [AWS CLI commands](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/index.html).
+*   [The Boto3 Python library](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html).
+
+Core AWS CLI operations such as `ls`, `cp`, `mv`, `rm`, and `sync` function as expected.
 
 ## AWS CLI examples
 

--- a/serverless/storage/s3-api.mdx
+++ b/serverless/storage/s3-api.mdx
@@ -14,12 +14,25 @@ Runpod provides an S3-protocol compatible API that allows direct access to your 
 
 Using the S3-compatible API to access your network volumes does not affect pricing. Network volumes are billed hourly at a rate of \$0.07 per GB per month for the first 1TB, and \$0.05 per GB per month for additional storage beyond that.
 
+## Datacenter availability
+
+The S3-compatible API is currently available for network volumes hosted in a limited number of datacenters.
+
+Each datacenter has an endpoint URL that you'll use when calling the S3-compatible API, using the format `https://s3api-[DATACENTER].runpod.io/`.
+
+Create a network volume in one of the following datacenters to use the S3-compatible API:
+
+| Datacenter | Endpoint URL |
+|-------------|--------------|
+| `EUR-IS-1` | `https://s3api-eur-is-1.runpod.io/` |
+| `EU-RO-1` | `https://s3api-eu-ro-1.runpod.io/` |
+
 ## Setup and authentication
 
 <Steps>
 <Step title="Create a network volume">
 
-    Before you can use the S3-compatible API, you must [create a network volume](/serverless/storage/network-volumes). The volume must be located in a [supported datacenter](#datacenter-availability) for the S3-compatible API to work.
+    Before you can use the S3-compatible API, you must create a network volume in a [supported datacenter](#datacenter-availability). For detailed instructions, see [Network volumes -> Create a network volume](/serverless/storage/network-volumes#create-a-network-volume).
 
 </Step>
 
@@ -57,19 +70,6 @@ Using the S3-compatible API to access your network volumes does not affect prici
   </Step>
 </Steps>
 
-## Datacenter availability
-
-The S3-compatible API is currently available for network volumes hosted in a limited number of datacenters.
-
-Each datacenter has an endpoint URL that you'll use when calling the S3-compatible API, using the format `https://s3api-[DATACENTER].runpod.io/`.
-
-Create a network volume in one of the following datacenters to use the S3-compatible API:
-
-| Datacenter | Endpoint URL |
-|-------------|--------------|
-| `EUR-IS-1` | `https://s3api-eur-is-1.runpod.io/` |
-| `EU-RO-1` | `https://s3api-eu-ro-1.runpod.io/` |
-
 ## Using the S3-compatible API
 
 You can use the S3-compatible API to interact with your Runpod network volumes using standard S3 tools:
@@ -81,7 +81,7 @@ Core AWS CLI operations such as `ls`, `cp`, `mv`, `rm`, and `sync` function as e
 
 ## AWS CLI examples
 
-When using AWS CLI commands, you must pass in the endpoint URL for your network volume ([listed above](#datacenter-availability)) using the `--endpoint-url` flag.
+When using AWS CLI commands, you must pass in the [endpoint URL](#datacenter-availability) for your network volume using the `--endpoint-url` flag.
 
 <Note>
 


### PR DESCRIPTION
- Added a step to setup and auth section to explicitly call out that you must create a network volume before using this API.
- Also moves datacenter availability up the page.