### PR TITLE
Update dual-mode-worker.mdx

### DIFF
--- a/serverless/development/dual-mode-worker.mdx
+++ b/serverless/development/dual-mode-worker.mdx
@@ -96,7 +96,7 @@ if mode_to_run == "pod":
 else: 
     runpod.serverless.start({
         "handler": handler,
-        "concurrency_modifier": adjust_concurrency,
+        "concurrency_modifier": 1,
     })
 
 ```


### PR DESCRIPTION
This should just be `1` b/c we aren't pulling an env variable. my mistake when fixing due to trying to streamline this.