### PR TITLE
WGET due to Web Console character limit

### DIFF
--- a/pods/configuration/use-ssh.mdx
+++ b/pods/configuration/use-ssh.mdx
@@ -129,7 +129,17 @@ Here are some common reasons why this might happen:
 ## Password-based SSH
 To use this method, your Pod must have a public IP address and expose TCP port 22. SSH will be accessible through a mapped external port.
 
-To quickly set up password-based SSH, copy and paste this code into your Pod's web terminal:
+To quickly set up password-based SSH, you have two options:
+
+### Option 1: wget and execute
+If you are using Runpod's web-terminal there is a character limit when you copy and paste, so wget to download and execute the file is an option.
+
+```
+wget https://raw.githubusercontent.com/justinwlin/Runpod-SSH-Password/main/passwordrunpod.sh && chmod +x passwordrunpod.sh && ./passwordrunpod.sh
+```
+
+### Option 2: Paste the code directly into your terminal
+If you have access to a terminal through Jupyter Notebook or other means, you can execute the script by copying and paste the command into the terminal.
 
 ```bash expandable Password-based SSH Script
 cat > /tmp/setup_ssh.sh << 'EOF' && chmod +x /tmp/setup_ssh.sh && /tmp/setup_ssh.sh


### PR DESCRIPTION
When pasting into the web console, there is a character limit, to where to get around it i instead wget the raw content, chmod it and execute it. I find this helpful for example our CPU pods are a bit of a hit or miss...