### PR TITLE
Small update to CopyParty Dependency

### DIFF
--- a/community-solutions/copyparty-file-manager/overview.mdx
+++ b/community-solutions/copyparty-file-manager/overview.mdx
@@ -23,7 +23,11 @@ Check the repository for additional features, updates, and documentation: [githu
 To use CopyParty on Runpod, you need:
 - **Terminal access to your Pod** - Either through web terminal or Jupyter Labs terminal.
 - An available HTTP port on your Pod.
-- Supported OS in the Docker base image (tested with Ubuntu based images, and Runpod official templates should work. Refer to the Github Repo for further support.)
+- Supported OS in the Docker base image
+
+<Note>
+CopyParty has been tested on Ubuntu based Docker images and Runpod Official templates. But for custom templates or templates that are using Docker base such as Python slim, there could be missing file system dependencies that the repository is expecting. Refer to the [Github repository](https://github.com/9001/copyparty) for support on different OS.
+</Note>
 
 ### Verifying terminal access
 

--- a/community-solutions/copyparty-file-manager/overview.mdx
+++ b/community-solutions/copyparty-file-manager/overview.mdx
@@ -23,10 +23,10 @@ Check the repository for additional features, updates, and documentation: [githu
 To use CopyParty on Runpod, you need:
 - **Terminal access to your Pod** - Either through web terminal or Jupyter Labs terminal.
 - An available HTTP port on your Pod.
-- Supported OS in the Docker base image
+- A supported OS in the Docker base image.
 
 <Note>
-CopyParty has been tested on Ubuntu based Docker images and Runpod Official templates. But for custom templates or templates that are using Docker base such as Python slim, there could be missing file system dependencies that the repository is expecting. Refer to the [Github repository](https://github.com/9001/copyparty) for support on different OS.
+CopyParty has been tested on Ubuntu-based Docker images and Runpod Official templates. When using custom templates or alternative Docker bases (like Python Slim) you may encounter file system dependency errors. Refer to the [GitHub repository](https://github.com/9001/copyparty) for details on OS support.
 </Note>
 
 ### Verifying terminal access

--- a/community-solutions/copyparty-file-manager/overview.mdx
+++ b/community-solutions/copyparty-file-manager/overview.mdx
@@ -23,6 +23,7 @@ Check the repository for additional features, updates, and documentation: [githu
 To use CopyParty on Runpod, you need:
 - **Terminal access to your Pod** - Either through web terminal or Jupyter Labs terminal.
 - An available HTTP port on your Pod.
+- Supported OS in the Docker base image (tested with Ubuntu based images, and Runpod official templates should work. Refer to the Github Repo for further support.)
 
 ### Verifying terminal access
 


### PR DESCRIPTION
Minor update, adding a bullet-point to point out that it does need an OS based Docker image.

I tried with a python:slim image, and had trouble with it, so I think there some OS level dependency after reading the github repo more, that is probably missing from a slim image
<img width="575" height="290" alt="Screenshot 2025-08-20 at 10 07 09 AM" src="https://github.com/user-attachments/assets/f4d62c26-371a-4b38-ab8a-d61056d1889d" />
