### PR TITLE
chore: run cpu/gpu reference list scripts

### DIFF
--- a/helpers/gpu_types.py
+++ b/helpers/gpu_types.py
@@ -30,23 +30,24 @@ file_path = os.path.join(
     os.path.dirname(__file__), "../references/gpu-types.mdx"
 )
 
-table = tabulate(gpus_df, headers=["GPU ID", "Display Name", "Memory (GB)"], tablefmt="github", showindex=False)
+table = tabulate(gpus_df.values.tolist(), headers=["GPU ID", "Display Name", "Memory (GB)"], tablefmt="github", showindex=False)
 
 with open(file_path, "w") as file:
     # Write the table headers
     date = datetime.now().strftime("%Y-%m-%d")
     file.write(
         f"""---
-title: GPU types
+title: "GPU types"
+description: "Explore the GPUs available on Runpod."
 ---
 
-The following list contains all GPU types available on Runpod.
+For information on pricing, see [GPU pricing](https://www.runpod.io/gpu-instance/pricing).
 
-For more information, see [GPU pricing](https://www.runpod.io/gpu-instance/pricing).
+## GPU types
 
-<!--
-Table last generated: {date}
--->
+This table lists all GPU types available on Runpod:
+{{/* Table last generated: {date} */}}
+
 {table}
 """)
 

--- a/helpers/sls_cpu_types.py
+++ b/helpers/sls_cpu_types.py
@@ -36,7 +36,7 @@ file_path = os.path.join(
     os.path.dirname(__file__), "../references/cpu-types.mdx"
 )
 
-table = tabulate(cpus_df, headers=["Display Name", "Cores", "Threads Per Core"], tablefmt="github", showindex=False)
+table = tabulate(cpus_df.values.tolist(), headers=["Display Name", "Cores", "Threads Per Core"], tablefmt="github", showindex=False)
 
 with open(file_path, "w") as file:
     # Write the headers and table
@@ -48,9 +48,8 @@ title: Serverless CPU types
 
 The following list contains all CPU types available on Runpod.
 
-<!--
-Table last generated: {date}
--->
+{{/* Table last generated: {date} */}}
+
 {table}
 """)
 

--- a/references/cpu-types.mdx
+++ b/references/cpu-types.mdx
@@ -1,269 +1,292 @@
 ---
-title: "Serverless CPU types"
+title: Serverless CPU types
 ---
 
 The following list contains all CPU types available on Runpod.
 
-| Display Name                                    | Cores | Threads Per Core |
-| ----------------------------------------------- | ----- | ---------------- |
-| 11th Gen Intel(R) Core(TM) i5-11400 @ 2.60GHz   | 6     | 2                |
-| 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz  | 6     | 2                |
-| 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz  | 2     | 1                |
-| 11th Gen Intel(R) Core(TM) i7-11700 @ 2.50GHz   | 8     | 2                |
-| 11th Gen Intel(R) Core(TM) i7-11700F @ 2.50GHz  | 8     | 2                |
-| 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz  | 8     | 2                |
-| 11th Gen Intel(R) Core(TM) i7-11700KF @ 3.60GHz | 8     | 2                |
-| 11th Gen Intel(R) Core(TM) i9-11900K @ 3.50GHz  | 8     | 2                |
-| 11th Gen Intel(R) Core(TM) i9-11900KF @ 3.50GHz | 8     | 2                |
-| 12th Gen Intel(R) Core(TM) i3-12100             | 4     | 2                |
-| 12th Gen Intel(R) Core(TM) i7-12700F            | 12    | 1                |
-| 12th Gen Intel(R) Core(TM) i7-12700K            | 12    | 1                |
-| 13th Gen Intel(R) Core(TM) i3-13100F            | 4     | 2                |
-| 13th Gen Intel(R) Core(TM) i5-13600K            | 14    | 1                |
-| 13th Gen Intel(R) Core(TM) i7-13700K            | 16    | 1                |
-| 13th Gen Intel(R) Core(TM) i7-13700KF           | 16    | 1                |
-| 13th Gen Intel(R) Core(TM) i9-13900F            | 24    | 1                |
-| 13th Gen Intel(R) Core(TM) i9-13900K            | 24    | 1                |
-| 13th Gen Intel(R) Core(TM) i9-13900KF           | 24    | 1                |
-| AMD Eng Sample: 100-000000053-04\_32/20\_N      | 48    | 1                |
-| AMD EPYC 4564P 16-Core Processor                | 16    | 2                |
-| AMD EPYC 7251 8-Core Processor                  | 8     | 2                |
-| AMD EPYC 7252 8-Core Processor                  | 8     | 2                |
-| AMD EPYC 7272 12-Core Processor                 | 12    | 2                |
-| AMD EPYC 7281 16-Core Processor                 | 16    | 2                |
-| AMD EPYC 7282 16-Core Processor                 | 16    | 2                |
-| AMD EPYC 7302 16-Core Processor                 | 16    | 2                |
-| AMD EPYC 7302P 16-Core Processor                | 16    | 2                |
-| AMD EPYC 7313 16-Core Processor                 | 16    | 2                |
-| AMD EPYC 7313P 16-Core Processor                | 16    | 2                |
-| AMD EPYC 7343 16-Core Processor                 | 16    | 2                |
-| AMD EPYC 7351P 16-Core Processor                | 16    | 2                |
-| AMD EPYC 7352 24-Core Processor                 | 24    | 2                |
-| AMD EPYC 7371 16-Core Processor                 | 16    | 2                |
-| AMD EPYC 7402 24-Core Processor                 | 24    | 2                |
-| AMD EPYC 7402P 24-Core Processor                | 24    | 2                |
-| AMD EPYC 7413 24-Core Processor                 | 24    | 2                |
-| AMD EPYC 7443 24-Core Processor                 | 48    | 1                |
-| AMD EPYC 7443P 24-Core Processor                | 24    | 2                |
-| AMD EPYC 7452 32-Core Processor                 | 32    | 2                |
-| AMD EPYC 7453 28-Core Processor                 | 28    | 1                |
-| AMD EPYC 74F3 24-Core Processor                 | 24    | 2                |
-| AMD EPYC 7502 32-Core Processor                 | 32    | 1                |
-| AMD EPYC 7502P 32-Core Processor                | 32    | 1                |
-| AMD EPYC 7513 32-Core Processor                 | 32    | 2                |
-| AMD EPYC 7532 32-Core Processor                 | 32    | 2                |
-| AMD EPYC 7542 32-Core Processor                 | 32    | 2                |
-| AMD EPYC 7543 32-Core Processor                 | 28    | 1                |
-| AMD EPYC 7543P 32-Core Processor                | 32    | 2                |
-| AMD EPYC 7551 32-Core Processor                 | 32    | 2                |
-| AMD EPYC 7551P 32-Core Processor                | 32    | 2                |
-| AMD EPYC 7552 48-Core Processor                 | 48    | 2                |
-| AMD EPYC 75F3 32-Core Processor                 | 32    | 2                |
-| AMD EPYC 7601 32-Core Processor                 | 32    | 2                |
-| AMD EPYC 7642 48-Core Processor                 | 48    | 2                |
-| AMD EPYC 7643 48-Core Processor                 | 48    | 2                |
-| AMD EPYC 7663 56-Core Processor                 | 56    | 2                |
-| AMD EPYC 7702 64-Core Processor                 | 64    | 2                |
-| AMD EPYC 7702P 64-Core Processor                | 64    | 2                |
-| AMD EPYC 7713 64-Core Processor                 | 64    | 1                |
-| AMD EPYC 7742 64-Core Processor                 | 64    | 2                |
-| AMD EPYC 7763 64-Core Processor                 | 64    | 2                |
-| AMD EPYC 7773X 64-Core Processor                | 64    | 2                |
-| AMD EPYC 7B12 64-Core Processor                 | 64    | 2                |
-| AMD EPYC 7B13 64-Core Processor                 | 64    | 1                |
-| AMD EPYC 7C13 64-Core Processor                 | 64    | 2                |
-| AMD EPYC 7F32 8-Core Processor                  | 8     | 2                |
-| AMD EPYC 7F52 16-Core Processor                 | 16    | 2                |
-| AMD EPYC 7F72 24-Core Processor                 | 24    | 2                |
-| AMD EPYC 7H12 64-Core Processor                 | 64    | 2                |
-| AMD EPYC 7K62 48-Core Processor                 | 48    | 2                |
-| AMD EPYC 7R32 48-Core Processor                 | 48    | 2                |
-| AMD EPYC 7T83 64-Core Processor                 | 127   | 1                |
-| AMD EPYC 7V13 64-Core Processor                 | 24    | 1                |
-| AMD EPYC 9124 16-Core Processor                 | 16    | 2                |
-| AMD EPYC 9254 24-Core Processor                 | 24    | 2                |
-| AMD EPYC 9274F 24-Core Processor                | 24    | 2                |
-| AMD EPYC 9354 32-Core Processor                 | 32    | 2                |
-| AMD EPYC 9354P                                  | 64    | 1                |
-| AMD EPYC 9354P 32-Core Processor                | 32    | 2                |
-| AMD EPYC 9374F 32-Core Processor                | 32    | 1                |
-| AMD EPYC 9454 48-Core Processor                 | 48    | 2                |
-| AMD EPYC 9454P 48-Core Emb Processor            | 48    | 2                |
-| AMD EPYC 9474F 48-Core Processor                | 48    | 2                |
-| AMD EPYC 9534 64-Core Processor                 | 64    | 2                |
-| AMD EPYC 9554 64-Core Emb Processor             | 64    | 1                |
-| AMD EPYC 9554 64-Core Processor                 | 126   | 1                |
-| AMD EPYC 9555 64-Core Processor                 | 56    | 2                |
-| AMD EPYC 9654 96-Core Emb Processor             | 96    | 1                |
-| AMD EPYC 9654 96-Core Processor                 | 96    | 2                |
-| AMD EPYC 9754 128-Core Processor                | 128   | 2                |
-| AMD EPYC Processor                              | 1     | 1                |
-| AMD EPYC Processor (with IBPB)                  | 16    | 1                |
-| AMD EPYC-Rome Processor                         | 16    | 1                |
-| AMD Ryzen 3 2200G with Radeon Vega Graphics     | 4     | 1                |
-| AMD Ryzen 3 3200G with Radeon Vega Graphics     | 4     | 1                |
-| AMD Ryzen 3 4100 4-Core Processor               | 4     | 2                |
-| AMD Ryzen 5 1600 Six-Core Processor             | 6     | 2                |
-| AMD Ryzen 5 2600 Six-Core Processor             | 6     | 2                |
-| AMD Ryzen 5 2600X Six-Core Processor            | 6     | 2                |
-| AMD Ryzen 5 3600 6-Core Processor               | 6     | 2                |
-| AMD Ryzen 5 3600X 6-Core Processor              | 6     | 2                |
-| AMD Ryzen 5 5500                                | 6     | 2                |
-| AMD Ryzen 5 5600G with Radeon Graphics          | 6     | 2                |
-| Ryzen 5 5600X                                   | 6     | 2                |
-| AMD Ryzen 5 7600 6-Core Processor               | 6     | 2                |
-| AMD Ryzen 5 PRO 2600 Six-Core Processor         | 6     | 2                |
-| AMD Ryzen 7 1700 Eight-Core Processor           | 8     | 2                |
-| AMD Ryzen 7 1700X Eight-Core Processor          | 8     | 2                |
-| AMD Ryzen 7 5700G with Radeon Graphics          | 8     | 2                |
-| AMD Ryzen 7 5700X 8-Core Processor              | 8     | 2                |
-| AMD Ryzen 7 5800X 8-Core Processor              | 8     | 2                |
-| AMD Ryzen 7 7700 8-Core Processor               | 8     | 2                |
-| AMD Ryzen 7 PRO 3700 8-Core Processor           | 8     | 2                |
-| AMD Ryzen 9 3900X 12-Core Processor             | 12    | 2                |
-| Ryzen 9 5900X                                   | 12    | 2                |
-| AMD Ryzen 9 5950X 16-Core Processor             | 16    | 2                |
-| AMD Ryzen 9 7900 12-Core Processor              | 12    | 2                |
-| AMD Ryzen 9 7950X 16-Core Processor             | 16    | 2                |
-| AMD Ryzen Threadripper 1900X 8-Core Processor   | 8     | 2                |
-| AMD Ryzen Threadripper 1920X 12-Core Processor  | 12    | 2                |
-| AMD Ryzen Threadripper 1950X 16-Core Processor  | 16    | 2                |
-| AMD Ryzen Threadripper 2920X 12-Core Processor  | 12    | 2                |
-| AMD Ryzen Threadripper 2950X 16-Core Processor  | 16    | 2                |
-| AMD Ryzen Threadripper 2970WX 24-Core Processor | 24    | 1                |
-| AMD Ryzen Threadripper 2990WX 32-Core Processor | 32    | 2                |
-| AMD Ryzen Threadripper 3960X 24-Core Processor  | 24    | 2                |
-| AMD Ryzen Threadripper 7960X 24-Cores           | 24    | 2                |
-| Ryzen Threadripper PRO 3955WX                   | 16    | 2                |
-| AMD Ryzen Threadripper PRO 3975WX 32-Cores      | 32    | 2                |
-| AMD Ryzen Threadripper PRO 3995WX 64-Cores      | 64    | 2                |
-| AMD Ryzen Threadripper PRO 5945WX 12-Cores      | 12    | 2                |
-| AMD Ryzen Threadripper PRO 5955WX 16-Cores      | 16    | 2                |
-| AMD Ryzen Threadripper PRO 5965WX 24-Cores      | 24    | 2                |
-| AMD Ryzen Threadripper PRO 5975WX 32-Cores      | 32    | 2                |
-| AMD Ryzen Threadripper PRO 5995WX 64-Cores      | 18    | 1                |
-| AMD Ryzen Threadripper PRO 7955WX 16-Cores      | 16    | 2                |
-| AMD Ryzen Threadripper PRO 7975WX 32-Cores      | 32    | 2                |
-| AMD Ryzen Threadripper PRO 7985WX 64-Cores      | 112   | 1                |
-| Common KVM processor                            | 28    | 1                |
-| Genuine Intel(R) CPU @ 2.20GHz                  | 14    | 2                |
-| Genuine Intel(R) CPU \$0000%@                   | 24    | 2                |
-| Intel Xeon Processor (Icelake)                  | 40    | 2                |
-| Intel(R) Celeron(R) CPU G3900 @ 2.80GHz         | 2     | 1                |
-| Intel(R) Celeron(R) G5905 CPU @ 3.50GHz         | 2     | 1                |
-| Intel(R) Core(TM) i3-10100F CPU @ 3.60GHz       | 4     | 2                |
-| Intel(R) Core(TM) i3-10105F CPU @ 3.70GHz       | 4     | 2                |
-| Intel(R) Core(TM) i3-6100 CPU @ 3.70GHz         | 2     | 2                |
-| Intel(R) Core(TM) i3-9100F CPU @ 3.60GHz        | 4     | 1                |
-| Intel(R) Core(TM) i5-10400 CPU @ 2.90GHz        | 6     | 2                |
-| Intel(R) Core(TM) i5-10400F CPU @ 2.90GHz       | 6     | 2                |
-| Intel(R) Core(TM) i5-10600 CPU @ 3.30GHz        | 6     | 2                |
-| Intel(R) Core(TM) i5-14500                      | 14    | 2                |
-| Intel(R) Core(TM) i5-14600K                     | 14    | 2                |
-| Intel(R) Core(TM) i5-14600KF                    | 14    | 2                |
-| Intel(R) Core(TM) i5-4570 CPU @ 3.20GHz         | 4     | 1                |
-| Intel(R) Core(TM) i5-6400 CPU @ 2.70GHz         | 4     | 1                |
-| Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz         | 4     | 1                |
-| Intel(R) Core(TM) i5-7400 CPU @ 3.00GHz         | 4     | 1                |
-| Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz        | 6     | 1                |
-| Intel(R) Core(TM) i7-10700F CPU @ 2.90GHz       | 8     | 2                |
-| Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz       | 8     | 2                |
-| Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz         | 4     | 2                |
-| Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz         | 4     | 2                |
-| Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz         | 4     | 2                |
-| Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz        | 4     | 2                |
-| Intel(R) Core(TM) i7-6800K CPU @ 3.40GHz        | 6     | 2                |
-| Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz        | 4     | 2                |
-| Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz         | 6     | 2                |
-| Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz         | 8     | 1                |
-| Intel(R) Core(TM) i9-10940X CPU @ 3.30GHz       | 14    | 2                |
-| Intel(R) Core(TM) i9-14900K                     | 24    | 1                |
-| Intel(R) Core(TM) Ultra 5 245K                  | 1     | 1                |
-| Intel(R) Pentium(R) CPU G3260 @ 3.30GHz         | 2     | 1                |
-| Intel(R) Pentium(R) CPU G4560 @ 3.50GHz         | 2     | 2                |
-| Intel(R) Xeon(R) 6960P                          | 72    | 2                |
-| Intel(R) Xeon(R) Bronze 3204 CPU @ 1.90GHz      | 6     | 1                |
-| Intel(R) Xeon(R) CPU X5660 @ 2.80GHz            | 6     | 2                |
-| Intel(R) Xeon(R) CPU E3-1220 v3 @ 3.10GHz       | 4     | 1                |
-| Intel(R) Xeon(R) CPU E3-1225 V2 @ 3.20GHz       | 4     | 1                |
-| Intel(R) Xeon(R) CPU E5-1650 v4 @ 3.60GHz       | 6     | 2                |
-| Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz       | 6     | 1                |
-| Intel(R) Xeon(R) CPU E5-2609 0 @ 2.40GHz        | 4     | 1                |
-| Intel(R) Xeon(R) CPU E5-2609 v3 @ 1.90GHz       | 1     | 1                |
-| Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz       | 8     | 2                |
-| Intel(R) Xeon(R) CPU E5-2630 0 @ 2.30GHz        | 6     | 2                |
-| Intel(R) Xeon(R) CPU E5-2630 v2 @ 2.60GHz       | 6     | 2                |
-| Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz       | 8     | 2                |
-| Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz       | 10    | 2                |
-| Intel(R) Xeon(R) CPU E5-2637 v2 @ 3.50GHz       | 4     | 2                |
-| Intel(R) Xeon(R) CPU E5-2643 0 @ 3.30GHz        | 4     | 1                |
-| Intel(R) Xeon(R) CPU E5-2648L v3 @ 1.80GHz      | 12    | 2                |
-| Intel(R) Xeon(R) CPU E5-2650 v3 @ 2.30GHz       | 10    | 2                |
-| Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz       | 12    | 2                |
-| Intel(R) Xeon(R) CPU E5-2660 v2 @ 2.20GHz       | 10    | 2                |
-| Intel(R) Xeon(R) CPU E5-2667 v2 @ 3.30GHz       | 1     | 1                |
-| Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz       | 8     | 2                |
-| Intel(R) Xeon(R) CPU E5-2667 v4 @ 3.20GHz       | 1     | 1                |
-| Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz        | 8     | 2                |
-| Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz       | 10    | 2                |
-| Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz       | 20    | 2                |
-| Intel(R) Xeon(R) CPU E5-2678 v3 @ 2.50GHz       | 12    | 2                |
-| Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz       | 12    | 2                |
-| Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz       | 14    | 2                |
-| Intel(R) Xeon(R) CPU E5-2683 v4 @ 2.10GHz       | 16    | 2                |
-| Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz        | 8     | 2                |
-| Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz       | 14    | 2                |
-| Intel(R) Xeon(R) CPU E5-2695 v4 @ 2.10GHz       | 18    | 2                |
-| Intel(R) Xeon(R) CPU E5-2696 v3 @ 2.30GHz       | 18    | 2                |
-| Intel(R) Xeon(R) CPU E5-2696 v4 @ 2.20GHz       | 22    | 2                |
-| Intel(R) Xeon(R) CPU E5-2698 v3 @ 2.30GHz       | 16    | 2                |
-| Intel(R) Xeon(R) CPU E5-2698 v4 @ 2.20GHz       | 20    | 2                |
-| Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz       | 1     | 1                |
-| Intel(R) Xeon(R) CPU E5-2699 v4 @ 2.20GHz       | 22    | 2                |
-| Intel(R) Xeon(R) CPU E5-4667 v3 @ 2.00GHz       | 16    | 2                |
-| Intel(R) Xeon(R) Gold 5118 CPU @ 2.30GHz        | 12    | 2                |
-| Intel(R) Xeon(R) Gold 5218R CPU @ 2.10GHz       | 20    | 2                |
-| Intel(R) Xeon(R) Gold 5318N CPU @ 2.10GHz       | 24    | 2                |
-| Intel(R) Xeon(R) Gold 5320 CPU @ 2.20GHz        | 26    | 2                |
-| Intel(R) Xeon(R) Gold 6130 CPU @ 2.10GHz        | 16    | 2                |
-| Intel(R) Xeon(R) Gold 6133 CPU @ 2.50GHz        | 40    | 1                |
-| Intel(R) Xeon(R) Gold 6136 CPU @ 3.00GHz        | 12    | 2                |
-| Intel(R) Xeon(R) Gold 6138 CPU @ 2.00GHz        | 20    | 2                |
-| Intel(R) Xeon(R) Gold 6150 CPU @ 2.70GHz        | 18    | 2                |
-| Intel(R) Xeon(R) Gold 6226 CPU @ 2.70GHz        | 12    | 2                |
-| Intel(R) Xeon(R) Gold 6238R CPU @ 2.20GHz       | 28    | 2                |
-| Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz       | 24    | 2                |
-| Intel(R) Xeon(R) Gold 6248R CPU @ 3.00GHz       | 16    | 1                |
-| Intel(R) Xeon(R) Gold 6252 CPU @ 2.10GHz        | 24    | 1                |
-| Intel(R) Xeon(R) Gold 6266C CPU @ 3.00GHz       | 22    | 2                |
-| Intel(R) Xeon(R) Gold 6342 CPU @ 2.80GHz        | 24    | 2                |
-| Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz        | 28    | 2                |
-| Intel(R) Xeon(R) Gold 6448Y                     | 32    | 2                |
-| Intel(R) Xeon(R) Platinum 8160 CPU @ 2.10GHz    | 24    | 2                |
-| Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70GHz    | 24    | 2                |
-| Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz   | 26    | 2                |
-| Intel(R) Xeon(R) Platinum 8173M CPU @ 2.00GHz   | 28    | 2                |
-| Intel(R) Xeon(R) Platinum 8176M CPU @ 2.10GHz   | 28    | 2                |
-| Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz    | 28    | 2                |
-| Intel(R) Xeon(R) Platinum 8352Y CPU @ 2.20GHz   | 32    | 2                |
-| Intel(R) Xeon(R) Platinum 8452Y                 | 36    | 2                |
-| Intel(R) Xeon(R) Platinum 8460Y+                | 40    | 2                |
-| Intel(R) Xeon(R) Platinum 8462Y+                | 32    | 2                |
-| Intel(R) Xeon(R) Platinum 8468                  | 48    | 2                |
-| Intel(R) Xeon(R) Platinum 8468V                 | 44    | 2                |
-| Intel(R) Xeon(R) Platinum 8470                  | 52    | 2                |
-| Intel(R) Xeon(R) Platinum 8480+                 | 56    | 2                |
-| Intel(R) Xeon(R) Platinum 8480C                 | 56    | 2                |
-| Intel(R) Xeon(R) Platinum 8480CL                | 56    | 2                |
-| INTEL(R) XEON(R) PLATINUM 8558                  | 48    | 2                |
-| INTEL(R) XEON(R) PLATINUM 8568Y+                | 48    | 2                |
-| INTEL(R) XEON(R) PLATINUM 8570                  | 56    | 2                |
-| Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz      | 10    | 2                |
-| Intel(R) Xeon(R) Silver 4210 CPU @ 2.20GHz      | 10    | 2                |
-| Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz      | 24    | 1                |
-| Intel(R) Xeon(R) Silver 4310T CPU @ 2.30GHz     | 10    | 2                |
-| Intel(R) Xeon(R) Silver 4314 CPU @ 2.40GHz      | 16    | 2                |
-| Intel(R) Xeon(R) W-2223 CPU @ 3.60GHz           | 4     | 2                |
-| Intel(R) Xeon(R) w5-2455X                       | 12    | 2                |
-| Intel(R) Xeon(R) w7-3465X                       | 28    | 2                |
-| QEMU Virtual CPU version 2.5+                   | 16    | 1                |
+{/* Table last generated: 2025-08-23 */}
+
+| Display Name                                    |   Cores |   Threads Per Core |
+|-------------------------------------------------|---------|--------------------|
+| 11th Gen Intel(R) Core(TM) i5-11400 @ 2.60GHz   |       6 |                  2 |
+| 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz  |       6 |                  2 |
+| 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz  |       2 |                  1 |
+| 11th Gen Intel(R) Core(TM) i7-11700 @ 2.50GHz   |       8 |                  2 |
+| 11th Gen Intel(R) Core(TM) i7-11700F @ 2.50GHz  |       8 |                  2 |
+| 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz  |       8 |                  2 |
+| 11th Gen Intel(R) Core(TM) i7-11700KF @ 3.60GHz |       8 |                  2 |
+| 11th Gen Intel(R) Core(TM) i9-11900K @ 3.50GHz  |       8 |                  2 |
+| 11th Gen Intel(R) Core(TM) i9-11900KF @ 3.50GHz |       8 |                  2 |
+| 12th Gen Intel(R) Core(TM) i3-12100             |       4 |                  2 |
+| 12th Gen Intel(R) Core(TM) i7-12700F            |      12 |                  1 |
+| 12th Gen Intel(R) Core(TM) i7-12700K            |      12 |                  1 |
+| 13th Gen Intel(R) Core(TM) i3-13100F            |       4 |                  2 |
+| 13th Gen Intel(R) Core(TM) i5-13600K            |      14 |                  1 |
+| 13th Gen Intel(R) Core(TM) i7-13700K            |      16 |                  1 |
+| 13th Gen Intel(R) Core(TM) i7-13700KF           |      16 |                  1 |
+| 13th Gen Intel(R) Core(TM) i9-13900F            |      24 |                  1 |
+| 13th Gen Intel(R) Core(TM) i9-13900K            |      24 |                  1 |
+| 13th Gen Intel(R) Core(TM) i9-13900KF           |      24 |                  1 |
+| AMD Eng Sample: 100-000000053-04_32/20_N        |      48 |                  1 |
+| AMD Eng Sample: 100-000000897-03                |      32 |                  2 |
+| AMD EPYC 4564P 16-Core Processor                |      16 |                  2 |
+| AMD EPYC 7251 8-Core Processor                  |       8 |                  2 |
+| AMD EPYC 7252 8-Core Processor                  |       8 |                  2 |
+| AMD EPYC 7272 12-Core Processor                 |      12 |                  2 |
+| AMD EPYC 7281 16-Core Processor                 |      16 |                  2 |
+| AMD EPYC 7282 16-Core Processor                 |      16 |                  2 |
+| AMD EPYC 7302 16-Core Processor                 |      16 |                  2 |
+| AMD EPYC 7302P 16-Core Processor                |      16 |                  2 |
+| AMD EPYC 7313 16-Core Processor                 |      16 |                  2 |
+| AMD EPYC 7313P 16-Core Processor                |      16 |                  2 |
+| AMD EPYC 7343 16-Core Processor                 |      16 |                  2 |
+| AMD EPYC 7351P 16-Core Processor                |      16 |                  2 |
+| AMD EPYC 7352 24-Core Processor                 |      24 |                  2 |
+| AMD EPYC 7371 16-Core Processor                 |      16 |                  2 |
+| AMD EPYC 7402 24-Core Processor                 |      24 |                  2 |
+| AMD EPYC 7402P 24-Core Processor                |      24 |                  2 |
+| AMD EPYC 7413 24-Core Processor                 |      24 |                  2 |
+| AMD EPYC 7443 24-Core Processor                 |      48 |                  1 |
+| AMD EPYC 7443P 24-Core Processor                |      24 |                  2 |
+| AMD EPYC 7452 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 7453 28-Core Processor                 |      28 |                  1 |
+| AMD EPYC 74F3 24-Core Processor                 |      24 |                  2 |
+| AMD EPYC 7502 32-Core Processor                 |      32 |                  1 |
+| AMD EPYC 7502P 32-Core Processor                |      32 |                  1 |
+| AMD EPYC 7513 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 7532 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 7542 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 7543 32-Core Processor                 |      28 |                  1 |
+| AMD EPYC 7543P 32-Core Processor                |      32 |                  2 |
+| AMD EPYC 7551 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 7551P 32-Core Processor                |      32 |                  2 |
+| AMD EPYC 7552 48-Core Processor                 |      48 |                  2 |
+| AMD EPYC 75F3 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 7601 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 7642 48-Core Processor                 |      48 |                  2 |
+| AMD EPYC 7643 48-Core Processor                 |      48 |                  2 |
+| AMD EPYC 7663 56-Core Processor                 |      56 |                  2 |
+| AMD EPYC 7702 64-Core Processor                 |      64 |                  2 |
+| AMD EPYC 7702P 64-Core Processor                |      64 |                  2 |
+| AMD EPYC 7713 64-Core Processor                 |      64 |                  1 |
+| AMD EPYC 7713P 64-Core Processor                |      64 |                  2 |
+| AMD EPYC 7742 64-Core Processor                 |      64 |                  2 |
+| AMD EPYC 7763 64-Core Processor                 |      64 |                  2 |
+| AMD EPYC 7773X 64-Core Processor                |      64 |                  2 |
+| AMD EPYC 7B12 64-Core Processor                 |      64 |                  2 |
+| AMD EPYC 7B13 64-Core Processor                 |      64 |                  1 |
+| AMD EPYC 7C13 64-Core Processor                 |      64 |                  2 |
+| AMD EPYC 7F32 8-Core Processor                  |       8 |                  2 |
+| AMD EPYC 7F52 16-Core Processor                 |      16 |                  2 |
+| AMD EPYC 7F72 24-Core Processor                 |      24 |                  2 |
+| AMD EPYC 7H12 64-Core Processor                 |      64 |                  2 |
+| AMD EPYC 7J13 64-Core Processor                 |      64 |                  2 |
+| AMD EPYC 7K62 48-Core Processor                 |      48 |                  2 |
+| AMD EPYC 7R32 48-Core Processor                 |      48 |                  2 |
+| AMD EPYC 7T83 64-Core Processor                 |     127 |                  1 |
+| AMD EPYC 7V13 64-Core Processor                 |      24 |                  1 |
+| AMD EPYC 9124 16-Core Processor                 |      16 |                  2 |
+| AMD EPYC 9254 24-Core Processor                 |      24 |                  2 |
+| AMD EPYC 9274F 24-Core Processor                |      24 |                  2 |
+| AMD EPYC 9334 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 9335 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 9354 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 9354P                                  |      64 |                  1 |
+| AMD EPYC 9354P 32-Core Processor                |      32 |                  2 |
+| AMD EPYC 9355 32-Core Processor                 |      32 |                  2 |
+| AMD EPYC 9355P 32-Core Processor                |      32 |                  2 |
+| AMD EPYC 9374F 32-Core Processor                |      32 |                  1 |
+| AMD EPYC 9454 48-Core Processor                 |      48 |                  2 |
+| AMD EPYC 9454P 48-Core Emb Processor            |      48 |                  2 |
+| AMD EPYC 9455P 48-Core Processor                |      48 |                  2 |
+| AMD EPYC 9474F 48-Core Processor                |      48 |                  2 |
+| AMD EPYC 9534 64-Core Processor                 |      64 |                  2 |
+| AMD EPYC 9554 64-Core Emb Processor             |      64 |                  1 |
+| AMD EPYC 9554 64-Core Processor                 |     126 |                  1 |
+| AMD EPYC 9555 64-Core Processor                 |      56 |                  2 |
+| AMD EPYC 9654 96-Core Emb Processor             |      96 |                  1 |
+| AMD EPYC 9654 96-Core Processor                 |      96 |                  2 |
+| AMD EPYC 9754 128-Core Processor                |     128 |                  2 |
+| AMD EPYC Processor                              |       1 |                  1 |
+| AMD EPYC Processor (with IBPB)                  |      16 |                  1 |
+| AMD EPYC-Rome Processor                         |      16 |                  1 |
+| AMD Ryzen 3 2200G with Radeon Vega Graphics     |       4 |                  1 |
+| AMD Ryzen 3 3200G with Radeon Vega Graphics     |       4 |                  1 |
+| AMD Ryzen 3 4100 4-Core Processor               |       4 |                  2 |
+| AMD Ryzen 5 1600 Six-Core Processor             |       6 |                  2 |
+| AMD Ryzen 5 2600 Six-Core Processor             |       6 |                  2 |
+| AMD Ryzen 5 2600X Six-Core Processor            |       6 |                  2 |
+| AMD Ryzen 5 3600 6-Core Processor               |       6 |                  2 |
+| AMD Ryzen 5 3600X 6-Core Processor              |       6 |                  2 |
+| AMD Ryzen 5 5500                                |       6 |                  2 |
+| AMD Ryzen 5 5600G with Radeon Graphics          |       6 |                  2 |
+| Ryzen 5 5600X                                   |       6 |                  2 |
+| AMD Ryzen 5 7600 6-Core Processor               |       6 |                  2 |
+| AMD Ryzen 5 8600G w/ Radeon 760M Graphics       |       6 |                  2 |
+| AMD Ryzen 5 PRO 2600 Six-Core Processor         |       6 |                  2 |
+| AMD Ryzen 7 1700 Eight-Core Processor           |       8 |                  2 |
+| AMD Ryzen 7 1700X Eight-Core Processor          |       8 |                  2 |
+| AMD Ryzen 7 5700G with Radeon Graphics          |       8 |                  2 |
+| AMD Ryzen 7 5700X 8-Core Processor              |       8 |                  2 |
+| AMD Ryzen 7 5800X 8-Core Processor              |       8 |                  2 |
+| AMD Ryzen 7 7700 8-Core Processor               |       8 |                  2 |
+| AMD Ryzen 7 PRO 3700 8-Core Processor           |       8 |                  2 |
+| AMD Ryzen 9 3900X 12-Core Processor             |      12 |                  2 |
+| Ryzen 9 5900X                                   |      12 |                  2 |
+| AMD Ryzen 9 5950X 16-Core Processor             |      16 |                  2 |
+| AMD Ryzen 9 7900 12-Core Processor              |      12 |                  2 |
+| AMD Ryzen 9 7950X 16-Core Processor             |      16 |                  2 |
+| AMD Ryzen 9 7950X3D 16-Core Processor           |      16 |                  2 |
+| AMD Ryzen 9 9950X 16-Core Processor             |      16 |                  2 |
+| AMD Ryzen Threadripper 1900X 8-Core Processor   |       8 |                  2 |
+| AMD Ryzen Threadripper 1920X 12-Core Processor  |      12 |                  2 |
+| AMD Ryzen Threadripper 1950X 16-Core Processor  |      16 |                  2 |
+| AMD Ryzen Threadripper 2920X 12-Core Processor  |      12 |                  2 |
+| AMD Ryzen Threadripper 2950X 16-Core Processor  |      16 |                  2 |
+| AMD Ryzen Threadripper 2970WX 24-Core Processor |      24 |                  1 |
+| AMD Ryzen Threadripper 2990WX 32-Core Processor |      32 |                  2 |
+| AMD Ryzen Threadripper 3960X 24-Core Processor  |      24 |                  2 |
+| AMD Ryzen Threadripper 7960X 24-Cores           |      24 |                  2 |
+| Ryzen Threadripper PRO 3955WX                   |      16 |                  2 |
+| AMD Ryzen Threadripper PRO 3975WX 32-Cores      |      32 |                  2 |
+| AMD Ryzen Threadripper PRO 3995WX 64-Cores      |      64 |                  2 |
+| AMD Ryzen Threadripper PRO 5945WX 12-Cores      |      12 |                  2 |
+| AMD Ryzen Threadripper PRO 5955WX 16-Cores      |      16 |                  2 |
+| AMD Ryzen Threadripper PRO 5965WX 24-Cores      |      24 |                  2 |
+| AMD Ryzen Threadripper PRO 5975WX 32-Cores      |      32 |                  2 |
+| AMD Ryzen Threadripper PRO 5995WX 64-Cores      |      18 |                  1 |
+| AMD Ryzen Threadripper PRO 7955WX 16-Cores      |      16 |                  2 |
+| AMD Ryzen Threadripper PRO 7965WX 24-Cores      |      24 |                  2 |
+| AMD Ryzen Threadripper PRO 7975WX 32-Cores      |      32 |                  2 |
+| AMD Ryzen Threadripper PRO 7985WX 64-Cores      |     112 |                  1 |
+| Common KVM processor                            |      28 |                  1 |
+| Genuine Intel(R) CPU @ 2.20GHz                  |      14 |                  2 |
+| Genuine Intel(R) CPU $0000%@                    |      24 |                  2 |
+| Intel Xeon E3-12xx v2 (Ivy Bridge)              |       1 |                  1 |
+| Intel Xeon Processor (Icelake)                  |      40 |                  2 |
+| Intel(R) Celeron(R) CPU G3900 @ 2.80GHz         |       2 |                  1 |
+| Intel(R) Celeron(R) G5905 CPU @ 3.50GHz         |       2 |                  1 |
+| Intel(R) Core(TM) i3-10100F CPU @ 3.60GHz       |       4 |                  2 |
+| Intel(R) Core(TM) i3-10105F CPU @ 3.70GHz       |       4 |                  2 |
+| Intel(R) Core(TM) i3-6100 CPU @ 3.70GHz         |       2 |                  2 |
+| Intel(R) Core(TM) i3-9100F CPU @ 3.60GHz        |       4 |                  1 |
+| Intel(R) Core(TM) i5-10400 CPU @ 2.90GHz        |       6 |                  2 |
+| Intel(R) Core(TM) i5-10400F CPU @ 2.90GHz       |       6 |                  2 |
+| Intel(R) Core(TM) i5-10600 CPU @ 3.30GHz        |       6 |                  2 |
+| Intel(R) Core(TM) i5-14500                      |      14 |                  2 |
+| Intel(R) Core(TM) i5-14600K                     |      14 |                  2 |
+| Intel(R) Core(TM) i5-14600KF                    |      14 |                  2 |
+| Intel(R) Core(TM) i5-4570 CPU @ 3.20GHz         |       4 |                  1 |
+| Intel(R) Core(TM) i5-6400 CPU @ 2.70GHz         |       4 |                  1 |
+| Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz         |       4 |                  1 |
+| Intel(R) Core(TM) i5-7400 CPU @ 3.00GHz         |       4 |                  1 |
+| Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz        |       6 |                  1 |
+| Intel(R) Core(TM) i7-10700F CPU @ 2.90GHz       |       8 |                  2 |
+| Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz       |       8 |                  2 |
+| Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz         |       4 |                  2 |
+| Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz         |       4 |                  2 |
+| Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz         |       4 |                  2 |
+| Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz        |       4 |                  2 |
+| Intel(R) Core(TM) i7-6800K CPU @ 3.40GHz        |       6 |                  2 |
+| Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz        |       4 |                  2 |
+| Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz         |       6 |                  2 |
+| Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz         |       8 |                  1 |
+| Intel(R) Core(TM) i9-10940X CPU @ 3.30GHz       |      14 |                  2 |
+| Intel(R) Core(TM) i9-14900K                     |      24 |                  1 |
+| Intel(R) Core(TM) Ultra 5 245K                  |       1 |                  1 |
+| Intel(R) Pentium(R) CPU G3260 @ 3.30GHz         |       2 |                  1 |
+| Intel(R) Pentium(R) CPU G4560 @ 3.50GHz         |       2 |                  2 |
+| Intel(R) Xeon(R) 6747P                          |      48 |                  2 |
+| Intel(R) Xeon(R) 6767P                          |      64 |                  2 |
+| Intel(R) Xeon(R) 6960P                          |      72 |                  2 |
+| Intel(R) Xeon(R) Bronze 3204 CPU @ 1.90GHz      |       6 |                  1 |
+| Intel(R) Xeon(R) CPU           X5660  @ 2.80GHz |       6 |                  2 |
+| Intel(R) Xeon(R) CPU E3-1220 v3 @ 3.10GHz       |       4 |                  1 |
+| Intel(R) Xeon(R) CPU E3-1225 V2 @ 3.20GHz       |       4 |                  1 |
+| Intel(R) Xeon(R) CPU E5-1650 v4 @ 3.60GHz       |       6 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz       |       6 |                  1 |
+| Intel(R) Xeon(R) CPU E5-2609 0 @ 2.40GHz        |       4 |                  1 |
+| Intel(R) Xeon(R) CPU E5-2609 v3 @ 1.90GHz       |       1 |                  1 |
+| Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz       |       8 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2630 0 @ 2.30GHz        |       6 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2630 v2 @ 2.60GHz       |       6 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz       |       8 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz       |      10 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2637 v2 @ 3.50GHz       |       4 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2643 0 @ 3.30GHz        |       4 |                  1 |
+| Intel(R) Xeon(R) CPU E5-2648L v3 @ 1.80GHz      |      12 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2650 v2 @ 2.60GHz       |      16 |                  1 |
+| Intel(R) Xeon(R) CPU E5-2650 v3 @ 2.30GHz       |      10 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz       |      12 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2660 v2 @ 2.20GHz       |      10 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2667 v2 @ 3.30GHz       |       1 |                  1 |
+| Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz       |       8 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2667 v4 @ 3.20GHz       |       1 |                  1 |
+| Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz        |       8 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz       |      10 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz       |      20 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2678 v3 @ 2.50GHz       |      12 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz       |      12 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz       |      14 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2683 v4 @ 2.10GHz       |      16 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz        |       8 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz       |      14 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2695 v4 @ 2.10GHz       |      18 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2696 v3 @ 2.30GHz       |      18 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2696 v4 @ 2.20GHz       |      22 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2698 v3 @ 2.30GHz       |      16 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2698 v4 @ 2.20GHz       |      20 |                  2 |
+| Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz       |       1 |                  1 |
+| Intel(R) Xeon(R) CPU E5-2699 v4 @ 2.20GHz       |      22 |                  2 |
+| Intel(R) Xeon(R) CPU E5-4667 v3 @ 2.00GHz       |      16 |                  2 |
+| Intel(R) Xeon(R) Gold 5118 CPU @ 2.30GHz        |      12 |                  2 |
+| Intel(R) Xeon(R) Gold 5218R CPU @ 2.10GHz       |      20 |                  2 |
+| Intel(R) Xeon(R) Gold 5220R CPU @ 2.20GHz       |      32 |                  1 |
+| Intel(R) Xeon(R) Gold 5318N CPU @ 2.10GHz       |      24 |                  2 |
+| Intel(R) Xeon(R) Gold 5320 CPU @ 2.20GHz        |      26 |                  2 |
+| Intel(R) Xeon(R) Gold 5420+                     |      28 |                  2 |
+| Intel(R) Xeon(R) Gold 6130 CPU @ 2.10GHz        |      16 |                  2 |
+| Intel(R) Xeon(R) Gold 6133 CPU @ 2.50GHz        |      40 |                  1 |
+| Intel(R) Xeon(R) Gold 6136 CPU @ 3.00GHz        |      12 |                  2 |
+| Intel(R) Xeon(R) Gold 6138 CPU @ 2.00GHz        |      20 |                  2 |
+| Intel(R) Xeon(R) Gold 6150 CPU @ 2.70GHz        |      18 |                  2 |
+| Intel(R) Xeon(R) Gold 6226 CPU @ 2.70GHz        |      12 |                  2 |
+| Intel(R) Xeon(R) Gold 6230R CPU @ 2.10GHz       |       8 |                  2 |
+| Intel(R) Xeon(R) Gold 6238R CPU @ 2.20GHz       |      28 |                  2 |
+| Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz       |      24 |                  2 |
+| Intel(R) Xeon(R) Gold 6248R CPU @ 3.00GHz       |      16 |                  1 |
+| Intel(R) Xeon(R) Gold 6252 CPU @ 2.10GHz        |      24 |                  1 |
+| Intel(R) Xeon(R) Gold 6266C CPU @ 3.00GHz       |      22 |                  2 |
+| Intel(R) Xeon(R) Gold 6342 CPU @ 2.80GHz        |      24 |                  2 |
+| Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz        |      28 |                  2 |
+| Intel(R) Xeon(R) Gold 6448Y                     |      32 |                  2 |
+| INTEL(R) XEON(R) GOLD 6548Y+                    |      32 |                  2 |
+| Intel(R) Xeon(R) Platinum 8160 CPU @ 2.10GHz    |      24 |                  2 |
+| Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70GHz    |      24 |                  2 |
+| Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz   |      26 |                  2 |
+| Intel(R) Xeon(R) Platinum 8173M CPU @ 2.00GHz   |      28 |                  2 |
+| Intel(R) Xeon(R) Platinum 8176M CPU @ 2.10GHz   |      28 |                  2 |
+| Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz    |      28 |                  2 |
+| Intel(R) Xeon(R) Platinum 8352V CPU @ 2.10GHz   |      36 |                  2 |
+| Intel(R) Xeon(R) Platinum 8352Y CPU @ 2.20GHz   |      32 |                  2 |
+| Intel(R) Xeon(R) Platinum 8452Y                 |      36 |                  2 |
+| Intel(R) Xeon(R) Platinum 8460Y+                |      40 |                  2 |
+| Intel(R) Xeon(R) Platinum 8462Y+                |      32 |                  2 |
+| Intel(R) Xeon(R) Platinum 8468                  |      48 |                  2 |
+| Intel(R) Xeon(R) Platinum 8468V                 |      44 |                  2 |
+| Intel(R) Xeon(R) Platinum 8470                  |      52 |                  2 |
+| Intel(R) Xeon(R) Platinum 8480+                 |      56 |                  2 |
+| Intel(R) Xeon(R) Platinum 8480C                 |      56 |                  2 |
+| Intel(R) Xeon(R) Platinum 8480CL                |      56 |                  2 |
+| INTEL(R) XEON(R) PLATINUM 8558                  |      48 |                  2 |
+| INTEL(R) XEON(R) PLATINUM 8568Y+                |      48 |                  2 |
+| INTEL(R) XEON(R) PLATINUM 8570                  |      56 |                  2 |
+| Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz      |      10 |                  2 |
+| Intel(R) Xeon(R) Silver 4210 CPU @ 2.20GHz      |      10 |                  2 |
+| Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz      |      24 |                  1 |
+| Intel(R) Xeon(R) Silver 4310T CPU @ 2.30GHz     |      10 |                  2 |
+| Intel(R) Xeon(R) Silver 4314 CPU @ 2.40GHz      |      16 |                  2 |
+| Intel(R) Xeon(R) W-2223 CPU @ 3.60GHz           |       4 |                  2 |
+| Intel(R) Xeon(R) w5-2455X                       |      12 |                  2 |
+| Intel(R) Xeon(R) w7-3465X                       |      28 |                  2 |
+| QEMU Virtual CPU version 2.5+                   |      16 |                  1 |

--- a/references/gpu-types.mdx
+++ b/references/gpu-types.mdx
@@ -3,54 +3,55 @@ title: "GPU types"
 description: "Explore the GPUs available on Runpod."
 ---
 
-
 For information on pricing, see [GPU pricing](https://www.runpod.io/gpu-instance/pricing).
 
 ## GPU types
 
 This table lists all GPU types available on Runpod:
+{/* Table last generated: 2025-08-23 */}
 
-{/* Table last generated: 2025-06-13 */}
-
-| GPU ID                                            | Display Name   |   Memory (GB) |
-|---------------------------------------------------|----------------|---------------|
-| AMD Instinct MI300X OAM                           | MI300X         |           192 |
-| NVIDIA A100 80GB PCIe                             | A100 PCIe      |            80 |
-| NVIDIA A100-SXM4-80GB                             | A100 SXM       |            80 |
-| NVIDIA A30                                        | A30            |            24 |
-| NVIDIA A40                                        | A40            |            48 |
-| NVIDIA B200                                       | B200           |           180 |
-| NVIDIA GeForce RTX 3070                           | RTX 3070       |             8 |
-| NVIDIA GeForce RTX 3080                           | RTX 3080       |            10 |
-| NVIDIA GeForce RTX 3080 Ti                        | RTX 3080 Ti    |            12 |
-| NVIDIA GeForce RTX 3090                           | RTX 3090       |            24 |
-| NVIDIA GeForce RTX 3090 Ti                        | RTX 3090 Ti    |            24 |
-| NVIDIA GeForce RTX 4070 Ti                        | RTX 4070 Ti    |            12 |
-| NVIDIA GeForce RTX 4080                           | RTX 4080       |            16 |
-| NVIDIA GeForce RTX 4080 SUPER                     | RTX 4080 SUPER |            16 |
-| NVIDIA GeForce RTX 4090                           | RTX 4090       |            24 |
-| NVIDIA GeForce RTX 5080                           | RTX 5080       |            16 |
-| NVIDIA GeForce RTX 5090                           | RTX 5090       |            32 |
-| NVIDIA H100 80GB HBM3                             | H100 SXM       |            80 |
-| NVIDIA H100 NVL                                   | H100 NVL       |            94 |
-| NVIDIA H100 PCIe                                  | H100 PCIe      |            80 |
-| NVIDIA H200                                       | H200 SXM       |           141 |
-| NVIDIA L4                                         | L4             |            24 |
-| NVIDIA L40                                        | L40            |            48 |
-| NVIDIA L40S                                       | L40S           |            48 |
-| NVIDIA RTX 2000 Ada Generation                    | RTX 2000 Ada   |            16 |
-| NVIDIA RTX 4000 Ada Generation                    | RTX 4000 Ada   |            20 |
-| NVIDIA RTX 5000 Ada Generation                    | RTX 5000 Ada   |            32 |
-| NVIDIA RTX 6000 Ada Generation                    | RTX 6000 Ada   |            48 |
-| NVIDIA RTX A2000                                  | RTX A2000      |             6 |
-| NVIDIA RTX A4000                                  | RTX A4000      |            16 |
-| NVIDIA RTX A4500                                  | RTX A4500      |            20 |
-| NVIDIA RTX A5000                                  | RTX A5000      |            24 |
-| NVIDIA RTX A6000                                  | RTX A6000      |            48 |
-| NVIDIA RTX PRO 6000 Blackwell Workstation Edition | RTX PRO 6000   |            96 |
-| Tesla V100-FHHL-16GB                              | V100 FHHL      |            16 |
-| Tesla V100-PCIE-16GB                              | Tesla V100     |            16 |
-| Tesla V100-SXM2-16GB                              | V100 SXM2      |            16 |
+| GPU ID                                            | Display Name             |   Memory (GB) |
+|---------------------------------------------------|--------------------------|---------------|
+| AMD Instinct MI300X OAM                           | MI300X                   |           192 |
+| NVIDIA A100 80GB PCIe                             | A100 PCIe                |            80 |
+| NVIDIA A100-SXM4-80GB                             | A100 SXM                 |            80 |
+| NVIDIA A30                                        | A30                      |            24 |
+| NVIDIA A40                                        | A40                      |            48 |
+| NVIDIA B200                                       | B200                     |           180 |
+| NVIDIA GeForce RTX 3070                           | RTX 3070                 |             8 |
+| NVIDIA GeForce RTX 3080                           | RTX 3080                 |            10 |
+| NVIDIA GeForce RTX 3080 Ti                        | RTX 3080 Ti              |            12 |
+| NVIDIA GeForce RTX 3090                           | RTX 3090                 |            24 |
+| NVIDIA GeForce RTX 3090 Ti                        | RTX 3090 Ti              |            24 |
+| NVIDIA GeForce RTX 4070 Ti                        | RTX 4070 Ti              |            12 |
+| NVIDIA GeForce RTX 4080                           | RTX 4080                 |            16 |
+| NVIDIA GeForce RTX 4080 SUPER                     | RTX 4080 SUPER           |            16 |
+| NVIDIA GeForce RTX 4090                           | RTX 4090                 |            24 |
+| NVIDIA GeForce RTX 5080                           | RTX 5080                 |            16 |
+| NVIDIA GeForce RTX 5090                           | RTX 5090                 |            32 |
+| NVIDIA H100 80GB HBM3                             | H100 SXM                 |            80 |
+| NVIDIA H100 NVL                                   | H100 NVL                 |            94 |
+| NVIDIA H100 PCIe                                  | H100 PCIe                |            80 |
+| NVIDIA H200                                       | H200 SXM                 |           141 |
+| NVIDIA L4                                         | L4                       |            24 |
+| NVIDIA L40                                        | L40                      |            48 |
+| NVIDIA L40S                                       | L40S                     |            48 |
+| NVIDIA RTX 2000 Ada Generation                    | RTX 2000 Ada             |            16 |
+| NVIDIA RTX 4000 Ada Generation                    | RTX 4000 Ada             |            20 |
+| NVIDIA RTX 4000 SFF Ada Generation                | RTX 4000 Ada SFF         |            20 |
+| NVIDIA RTX 5000 Ada Generation                    | RTX 5000 Ada             |            32 |
+| NVIDIA RTX 6000 Ada Generation                    | RTX 6000 Ada             |            48 |
+| NVIDIA RTX A2000                                  | RTX A2000                |             6 |
+| NVIDIA RTX A4000                                  | RTX A4000                |            16 |
+| NVIDIA RTX A4500                                  | RTX A4500                |            20 |
+| NVIDIA RTX A5000                                  | RTX A5000                |            24 |
+| NVIDIA RTX A6000                                  | RTX A6000                |            48 |
+| NVIDIA RTX PRO 6000 Blackwell Server Edition      | RTX PRO 6000 Server      |            96 |
+| NVIDIA RTX PRO 6000 Blackwell Workstation Edition | RTX PRO 6000 Workstation |            96 |
+| Tesla V100-FHHL-16GB                              | V100 FHHL                |            16 |
+| Tesla V100-PCIE-16GB                              | Tesla V100               |            16 |
+| Tesla V100-SXM2-16GB                              | V100 SXM2                |            16 |
+| Tesla V100-SXM2-32GB                              | V100 SXM2 32GB           |            32 |
 
 ## GPU pools
 


### PR DESCRIPTION
the diff will not be pretty if you don't have "no whitespace" enabled due to the introduction of longer cpu/gpu names.