### PR TITLE
Remove GitHub star count from navbar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -494,13 +494,15 @@
       {
         "label": "Sign up",
         "href": "https://console.runpod.io/signup"
+      },
+      {
+        "label": "runpod/docs",
+        "href": "https://github.com/runpod/docs",
+        "icon": "github"
       }
-    ],
-    "primary": {
-      "type": "github",
-        "href": "https://github.com/runpod/docs"
-      }
-    },
+    ]
+  },
+  
   "footer": {
     "socials": {
       "discord": "https://discord.gg/cUpRmau42V",


### PR DESCRIPTION
TL:DR: showing 35 stars on the docs isn't a good look, we should remove the number count so people don't think we just started


Move GitHub link from navbar.primary to navbar.links to display repository link without automatic star count fetching