### PR TITLE
docs(hub): missing "required" example

### DIFF
--- a/hub/publishing-guide.mdx
+++ b/hub/publishing-guide.mdx
@@ -111,6 +111,7 @@ Environment variables can be defined in several ways:
         "name": "Hugging Face Model",
         "description": "Model organization/name as listed on Huggingface Hub",
         "default": "runwayml/stable-diffusion-v1-5",
+        "required": true
       }
     }
     ```


### PR DESCRIPTION
## Motivation

* I was checking the docs for the hub.json and realized that we have no example for `required: true`, so i updated one of the examples

@muhsinking this is not enough, we should have a list of possible values for an env, so that it is clear for a human and also for an agent on how to create the hub.json correctly and what the default value is for fields, for example that `required = false` is the default and you only need to set it to true on the fields that should not be required. but this is currently not clear at all in the docs