### PR TITLE
Add US-IL-1, US-MO-1, and US-WA-1 to S3-compatible API datacenter lists

### DIFF
--- a/pods/storage/create-network-volumes.mdx
+++ b/pods/storage/create-network-volumes.mdx
@@ -116,7 +116,7 @@ The S3-compatible API supports standard S3 operations including file uploads, do
 For detailed setup instructions, authentication, and usage examples, see the [S3-compatible API documentation](/serverless/storage/s3-api).
 
 <Note>
-The S3-compatible API is currently available for network volumes in the following datacenters: `EUR-IS-1`, `EU-RO-1`, `EU-CZ-1`, `US-KS-2`, `US-CA-2`.
+The S3-compatible API is currently available for network volumes in the following datacenters: `EUR-IS-1`, `EU-RO-1`, `EU-CZ-1`, `US-CA-2`, `US-IL-1`, `US-KS-2`, `US-MO-1`, `US-WA-1`.
 </Note>
 
 ## Architecture details

--- a/serverless/storage/network-volumes.mdx
+++ b/serverless/storage/network-volumes.mdx
@@ -104,7 +104,7 @@ Runpod provides an S3-compatible API that allows you to access and manage files 
 For detailed setup instructions, authentication, and comprehensive usage examples, see the [S3-compatible API documentation](/serverless/storage/s3-api).
 
 <Note>
-The S3-compatible API is currently available for network volumes in the following datacenters: `EUR-IS-1`, `EU-RO-1`, `EU-CZ-1`, `US-KS-2`, `US-CA-2`.
+The S3-compatible API is currently available for network volumes in the following datacenters: `EUR-IS-1`, `EU-RO-1`, `EU-CZ-1`, `US-CA-2`, `US-IL-1`, `US-KS-2`, `US-MO-1`, `US-WA-1`.
 </Note>
 
 ## Architecture details

--- a/storage/network-volumes.mdx
+++ b/storage/network-volumes.mdx
@@ -165,7 +165,7 @@ The S3-compatible API supports standard S3 operations including file uploads, do
 
 <Note>
 
-The S3-compatible API is currently available for network volumes in the following datacenters: `EUR-IS-1`, `EU-RO-1`, `EU-CZ-1`, `US-KS-2`, `US-CA-2`.
+The S3-compatible API is currently available for network volumes in the following datacenters: `EUR-IS-1`, `EU-RO-1`, `EU-CZ-1`, `US-CA-2`, `US-IL-1`, `US-KS-2`, `US-MO-1`, `US-WA-1`.
 
 </Note>
 

--- a/storage/s3-api.mdx
+++ b/storage/s3-api.mdx
@@ -21,8 +21,11 @@ The S3-compatible API is available for network volumes in select datacenters. Ea
 | `EUR-IS-1` | `https://s3api-eur-is-1.runpod.io/` |
 | `EU-RO-1`  | `https://s3api-eu-ro-1.runpod.io/`  |
 | `EU-CZ-1`  | `https://s3api-eu-cz-1.runpod.io/`  |
+| `US-CA-2`  | `https://s3api-us-ca-2.runpod.io/`  |
+| `US-IL-1`  | `https://s3api-us-il-1.runpod.io/`  |
 | `US-KS-2`  | `https://s3api-us-ks-2.runpod.io/`  |
-| `US-CA-2` | `https://s3api-us-ca-2.runpod.io/`  |
+| `US-MO-1`  | `https://s3api-us-mo-1.runpod.io/`  |
+| `US-WA-1`  | `https://s3api-us-wa-1.runpod.io/`  |
 
 Create your network volume in a supported datacenter to use the S3-compatible API.
 


### PR DESCRIPTION
Three new US datacenters now support the S3-compatible API for network volumes: Illinois (US-IL-1), Missouri (US-MO-1), and Washington (US-WA-1).

**Changes:**
- Updated datacenter availability table in `storage/s3-api.mdx` with endpoint URLs for new regions
- Updated datacenter lists in network volume documentation across `storage/`, `pods/storage/`, and `serverless/storage/` paths
- Maintained alphabetical ordering by datacenter code

**Complete US datacenter list:**
- US-CA-2, US-IL-1, US-KS-2, US-MO-1, US-WA-1

European datacenters (EUR-IS-1, EU-RO-1, EU-CZ-1) unchanged.
