### PR TITLE
Fix docs robots.txt warning

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /cdn-cgi/
+Allow: /_next/image
+Disallow: /_next/
+Sitemap: https://docs.runpod.io/sitemap.xml


### PR DESCRIPTION
Adds a custom root robots.txt for the Mintlify docs site to keep the current crawl rules and sitemap while removing the non-standard Content-Signal directive that Googlebot ignores in Search Console.\n\nValidation:\n- node scripts/validate-tooltips.js