### PR TITLE
docs: Add alt text to serverless endpoint details screenshots

### DIFF
--- a/serverless/endpoints/send-requests.mdx
+++ b/serverless/endpoints/send-requests.mdx
@@ -53,7 +53,7 @@ The exact parameters depend on your specific worker implementation. Check your w
 The quickest way to test your endpoint is in the Runpod console. Navigate to [Serverless](https://www.console.runpod.io/serverless), select your endpoint, and click the **Requests** tab.
 
 <Frame>
-  <img src="/images/8f34ba77-serverless-get-started-endpoint-details.png" />
+  <img src="/images/8f34ba77-serverless-get-started-endpoint-details.png" alt="Runpod serverless endpoint details page" />
 </Frame>
 
 Modify the default test request as needed, then click **Run**. On first execution, workers need to initialize, which may take a moment.

--- a/serverless/quickstart.mdx
+++ b/serverless/quickstart.mdx
@@ -187,7 +187,7 @@ The system will redirect you to a dedicated detail page for your new endpoint.
 To test your endpoint, click the **Requests** tab in the endpoint detail page:
 
 <Frame>
-  <img src="/images/8f34ba77-serverless-get-started-endpoint-details.png" />
+  <img src="/images/8f34ba77-serverless-get-started-endpoint-details.png" alt="Runpod serverless endpoint details page" />
 </Frame>
 
 On the left you should see the default test request:

--- a/serverless/vllm/get-started.mdx
+++ b/serverless/vllm/get-started.mdx
@@ -61,7 +61,7 @@ Once deployment is complete, make a note of your **Endpoint ID**, as you'll need
 To test your worker, click the **Requests** tab in the endpoint detail page:
 
 <Frame>
-  <img src="/images/8f34ba77-serverless-get-started-endpoint-details.png" />
+  <img src="/images/8f34ba77-serverless-get-started-endpoint-details.png" alt="Runpod serverless endpoint details page" />
 </Frame>
 
 On the left you should see the default test request:


### PR DESCRIPTION
## Summary
Adds descriptive alt text (`alt="Runpod serverless endpoint details page"`) to the endpoint details screenshot (`/images/8f34ba77-serverless-get-started-endpoint-details.png`) referenced in three docs pages:
- `serverless/quickstart.mdx`
- `serverless/endpoints/send-requests.mdx`
- `serverless/vllm/get-started.mdx`

This prepares the source fix for the remaining live missing-alt finding. The live docs image will remain missing `alt` until this PR is merged and the docs site deploys.

## Validation
- `git diff --check origin/main...HEAD` passes.
- `vale serverless/quickstart.mdx serverless/endpoints/send-requests.mdx serverless/vllm/get-started.mdx` still reports pre-existing style issues, including 9 existing errors in `serverless/vllm/get-started.mdx`. The new alt-only lines do not introduce new Vale findings.
- GitHub check `Check tooltip imports` passes. Mintlify validation/deployment checks are skipped on this PR.
