### PR TITLE
SLS-238: pin runpod/pytorch docs refs to existing tags

### DIFF
--- a/runpodctl/reference/runpodctl-pod.mdx
+++ b/runpodctl/reference/runpodctl-pod.mdx
@@ -105,7 +105,7 @@ Template ID to use for Pod configuration. Use [`runpodctl template search`](/run
 </ResponseField>
 
 <ResponseField name="--image" type="string">
-Docker image to use (e.g., `runpod/pytorch:latest`). Required if no template specified.
+Docker image to use (e.g., `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04`). Required if no template specified.
 </ResponseField>
 
 <ResponseField name="--name" type="string">

--- a/runpodctl/reference/runpodctl-template.mdx
+++ b/runpodctl/reference/runpodctl-template.mdx
@@ -106,7 +106,7 @@ Create a new template:
 
 ```bash
 # Create a Pod template
-runpodctl template create --name "my-template" --image "runpod/pytorch:latest"
+runpodctl template create --name "my-template" --image "runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04"
 
 # Create a Serverless template
 runpodctl template create --name "my-serverless-template" --image "my-image:latest" --serverless
@@ -125,7 +125,7 @@ Template name.
 </ResponseField>
 
 <ResponseField name="--image" type="string" required>
-Docker image (e.g., `runpod/pytorch:latest`).
+Docker image (e.g., `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04`).
 </ResponseField>
 
 <ResponseField name="--container-disk-in-gb" type="int" default="20">


### PR DESCRIPTION
## Summary

SLS-8 flipped Layer 2 image verification to enforce. Customer-facing pod-creates that reference an image tag returning HTTP 404 now hard-fail with IMAGE_VALIDATION_FAILED.

The tag `runpod/pytorch:latest` returns 404 on the registry, so docs that tell customers to use it will cause failed deploys. This PR pins those references to a published tag.

## Changes

- `runpod/pytorch:latest` -> `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04` (3 occurrences across 2 files)

No bare `runpod/pytorch:2.4.0` references were present in the repo; the only `2.4.0` reference is already full-pinned and was left untouched.

## Test plan

- Grep confirms zero remaining `runpod/pytorch:latest` and zero bare `runpod/pytorch:2.4.0` references.

Reference: SLS-238