### PR TITLE
docs: add connect workflow page to navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -39,6 +39,7 @@
             "pages": [
               "overview",
               "get-started",
+              "get-started/connect-to-runpod",
               "get-started/concepts",
               "get-started/api-keys",
               "get-started/agent-skills",


### PR DESCRIPTION
## Summary
- Add `get-started/connect-to-runpod` to the Get started navigation in `docs.json`.
- Gives the existing Choose a workflow page an internal docs navigation link so it is no longer orphaned.

## Validation
- `python3 -m json.tool docs.json`
- `node scripts/validate-tooltips.js` (passes with existing unused-import warnings)