### PR TITLE
Add H1s to Ahrefs-flagged docs pages

### DIFF
--- a/pods/troubleshooting/storage-full.mdx
+++ b/pods/troubleshooting/storage-full.mdx
@@ -2,6 +2,8 @@
 title: "Storage full"
 ---
 
+# Storage full
+
 Storage full errors can occur when users generate many files, transfer files, or perform other storage-intensive tasks. This document provides guidance to help you troubleshoot this.
 
 ## Check disk usage

--- a/public-endpoints/models/nano-banana-2-edit.mdx
+++ b/public-endpoints/models/nano-banana-2-edit.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Nano Banana 2"
 description: "Google's latest multi-image editing model with resolution options up to 4K."
 ---
 
+# Nano Banana 2 Edit
+
 Nano Banana 2 Edit is Google's latest image editing model for combining and editing multiple reference images. It supports up to 14 input images and offers resolution options from 1K to 4K output. For best results, use 1-3 reference images.
 
 <Card title="Try in playground" icon="play" href="https://console.runpod.io/hub/playground/image/google-nano-banana-2-edit" horizontal>

--- a/public-endpoints/requests.mdx
+++ b/public-endpoints/requests.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Make API requests"
 description: "Use the playground, REST API, and SDKs to interact with Public Endpoints."
 ---
 
+# Make API requests
+
 This guide covers all the ways to interact with Public Endpoints, from testing in the browser to integrating with your applications.
 
 ## Requirements

--- a/runpodctl/overview.mdx
+++ b/runpodctl/overview.mdx
@@ -6,6 +6,8 @@ description: "Use Runpod CLI to manage Pods, Serverless endpoints, templates, an
 
 import { PodsTooltip, PodTooltip } from "/snippets/tooltips.jsx";
 
+# Runpod CLI
+
 Runpod CLI is an [open source](https://github.com/runpod/runpodctl) command-line tool for managing your Runpod resources from your local machine. You can manage Pods, Serverless endpoints, templates, network volumes, and models, transfer files between your system and Runpod, diagnose issues, and view account information.
 
 ## Quick start

--- a/serverless/workers/deploy.mdx
+++ b/serverless/workers/deploy.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Deploy from Docker Hub"
 description: "Build, test, and deploy your worker image from Docker Hub."
 ---
 
+# Deploy workers from Docker Hub
+
 After [creating a Dockerfile](/serverless/workers/create-dockerfile) for your worker, you can build the image, test it locally, and deploy it to a Serverless endpoint.
 
 ## Requirements

--- a/serverless/workers/overview.mdx
+++ b/serverless/workers/overview.mdx
@@ -6,6 +6,8 @@ mode: "wide"
 
 import { MachineTooltip } from "/snippets/tooltips.jsx";
 
+# Serverless workers
+
 <div className="overview-page-wrapper" />
 
 Workers are containerized environments that run your code on Runpod Serverless.

--- a/tutorials/introduction/containers/create-dockerfiles.mdx
+++ b/tutorials/introduction/containers/create-dockerfiles.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Create Dockerfiles"
 description: "Learn how to write Dockerfiles, build custom images, and run your first containers."
 ---
 
+# Create Dockerfiles
+
 A Dockerfile is a text file containing instructions for building a Docker image. By creating a Dockerfile, you can package your application with its dependencies and configuration, making it easy to deploy anywhere Docker runs. This guide walks you through creating your first Dockerfile, building an image, and running a container.
 
 ## Requirements


### PR DESCRIPTION
## Summary
- Adds explicit page-level H1s to the seven docs pages currently flagged in Ahrefs for missing H1 tags.
- Uses descriptive headings for generic overview pages, for example Runpod CLI and Serverless workers.

## Validation
- node scripts/validate-tooltips.js
- git diff --check

## Ahrefs context
Issue: missing H1 tags from project 3648513, issue c64d9d0b-d0f4-11e7-8ed1-001e67ed4656.