### PR TITLE
Add redirects for 52 legacy doc paths still returning 404 (batch 3)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1092,6 +1092,214 @@
     {
       "source": "/troubleshooting",
       "destination": "/serverless/troubleshooting"
+    },
+    {
+      "source": "/faq",
+      "destination": "/get-started/concepts"
+    },
+    {
+      "source": "/graphql-api",
+      "destination": "/sdks/graphql/manage-pods"
+    },
+    {
+      "source": "/hosting/overview",
+      "destination": "/references/security-and-compliance"
+    },
+    {
+      "source": "/docs/start-pod",
+      "destination": "/sdks/graphql/manage-pods"
+    },
+    {
+      "source": "/hosting/burn-testing",
+      "destination": "/references/security-and-compliance"
+    },
+    {
+      "source": "/hosting/maintenance-and-reliability",
+      "destination": "/references/security-and-compliance"
+    },
+    {
+      "source": "/docs/graphql-api",
+      "destination": "/sdks/graphql/manage-pods"
+    },
+    {
+      "source": "/tutorials/migrations/banana/overview",
+      "destination": "/serverless/overview"
+    },
+    {
+      "source": "/docs",
+      "destination": "/get-started"
+    },
+    {
+      "source": "/docs/serverless-endpoint-urls",
+      "destination": "/serverless/endpoints/send-requests"
+    },
+    {
+      "source": "/tutorials/text-to-video-pipeline",
+      "destination": "/tutorials/public-endpoints/text-to-video-pipeline"
+    },
+    {
+      "source": "/ai-endpoints/image-based/dreambooth-sd-v1.5",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/scaling",
+      "destination": "/serverless/endpoints/endpoint-configurations"
+    },
+    {
+      "source": "/templates",
+      "destination": "/pods/templates/overview"
+    },
+    {
+      "source": "/model-management",
+      "destination": "/serverless/endpoints/model-caching"
+    },
+    {
+      "source": "/category/workers",
+      "destination": "/serverless/workers/overview"
+    },
+    {
+      "source": "/api/errors",
+      "destination": "/api-reference/overview"
+    },
+    {
+      "source": "/docker/create",
+      "destination": "/tutorials/introduction/containers/create-dockerfiles"
+    },
+    {
+      "source": "/secrets",
+      "destination": "/pods/templates/secrets"
+    },
+    {
+      "source": "/serverless-gpu/overview",
+      "destination": "/serverless/overview"
+    },
+    {
+      "source": "/docs/using-your-api",
+      "destination": "/serverless/endpoints/send-requests"
+    },
+    {
+      "source": "/inference/llm/vllm",
+      "destination": "/serverless/vllm/overview"
+    },
+    {
+      "source": "/serverless-ai/runpod-apis",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/references/runpodctl/runpodctl_start_pod",
+      "destination": "/runpodctl/reference/runpodctl-pod"
+    },
+    {
+      "source": "/logging",
+      "destination": "/serverless/development/logs"
+    },
+    {
+      "source": "/docs/pods",
+      "destination": "/pods/overview"
+    },
+    {
+      "source": "/pricing/serverless",
+      "destination": "/serverless/pricing"
+    },
+    {
+      "source": "/docs/faq",
+      "destination": "/get-started/concepts"
+    },
+    {
+      "source": "/docs/automatic-stop",
+      "destination": "/pods/manage-pods"
+    },
+    {
+      "source": "/reference/pygmalion-6b",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/tutorials/run-ollama-on-pods",
+      "destination": "/tutorials/pods/run-ollama"
+    },
+    {
+      "source": "/serverless-ai/custom-apis",
+      "destination": "/serverless/overview"
+    },
+    {
+      "source": "/serverless/handler-api",
+      "destination": "/serverless/workers/handler-functions"
+    },
+    {
+      "source": "/serverless-endpoints",
+      "destination": "/serverless/endpoints/overview"
+    },
+    {
+      "source": "/serverless/deploy-with-vllm",
+      "destination": "/serverless/vllm/overview"
+    },
+    {
+      "source": "/serverless/timeout",
+      "destination": "/serverless/endpoints/endpoint-configurations"
+    },
+    {
+      "source": "/reference/runpod-apis",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/serverless/endpoints/get-job-status",
+      "destination": "/serverless/endpoints/operation-reference"
+    },
+    {
+      "source": "/serverless-workers/vllm",
+      "destination": "/serverless/vllm/overview"
+    },
+    {
+      "source": "/docs/network-volumes",
+      "destination": "/storage/network-volumes"
+    },
+    {
+      "source": "/tutorials/deploy-cached-models",
+      "destination": "/tutorials/serverless/model-caching-text"
+    },
+    {
+      "source": "/graphql/spec",
+      "destination": "/sdks/graphql/manage-pods"
+    },
+    {
+      "source": "/quickstart",
+      "destination": "/get-started"
+    },
+    {
+      "source": "/docs/errors",
+      "destination": "/serverless/troubleshooting"
+    },
+    {
+      "source": "/docs/docker",
+      "destination": "/containers"
+    },
+    {
+      "source": "/docs/handler-additional-controls",
+      "destination": "/serverless/workers/handler-functions"
+    },
+    {
+      "source": "/docs/connect-to-pod",
+      "destination": "/pods/connect-to-a-pod"
+    },
+    {
+      "source": "/deployment-guide",
+      "destination": "/serverless/workers/deploy"
+    },
+    {
+      "source": "/category/vllm-endpoint",
+      "destination": "/serverless/vllm/overview"
+    },
+    {
+      "source": "/docs/custom-apis",
+      "destination": "/serverless/overview"
+    },
+    {
+      "source": "/docs/volume-mounts",
+      "destination": "/pods/storage/types"
+    },
+    {
+      "source": "/tutorials/integrate-serverless-with-web-applications",
+      "destination": "/serverless/endpoints/send-requests"
     }
   ]
 }

--- a/overview.mdx
+++ b/overview.mdx
@@ -132,4 +132,3 @@ Create a multi-node [Instant Cluster](/instant-clusters) for fully managed distr
         Join the Runpod community on Discord.
     </Card>
 </CardGroup>
-


### PR DESCRIPTION
## What

Third batch of legacy-path redirects. The Ahrefs Site Audit 4XX issue flags 56 docs.runpod.io paths still returning 404 (verified against the live site today). These are leftovers from the GitBook, ReadMe (`/docs/*`, `/reference/*`), and Docusaurus (`/category/*`, `/hosting/*`) eras of the docs site. Several sources carry external backlinks (page rating 5-7 in Ahrefs), so they leak authority and strand real visitors.

Follows the same method as #692 and #694: each path mapped to the closest current content-equivalent page (exact successor > renamed feature's new home > category target > nearest section overview), every destination verified live (HTTP 200), and no destination is itself a redirect source (one hop only). Old-page content was confirmed via this repo's git history (GitBook/ReadMe-era trees) and the Wayback Machine where available.

## Change

Adds 52 entries to the `redirects` array in `docs.json`. Also normalizes a trailing blank line in `overview.mdx` (whitespace-only) so the .mdx-path-filtered "Check tooltip imports" workflow and the Mintlify staging deployment both run on this PR.

## Mapping

| Legacy source | Destination |
| --- | --- |
| `/faq` | `/get-started/concepts` |
| `/docs/faq` | `/get-started/concepts` |
| `/graphql-api` | `/sdks/graphql/manage-pods` |
| `/docs/graphql-api` | `/sdks/graphql/manage-pods` |
| `/graphql/spec` | `/sdks/graphql/manage-pods` |
| `/docs/start-pod` | `/sdks/graphql/manage-pods` |
| `/hosting/overview` | `/references/security-and-compliance` |
| `/hosting/burn-testing` | `/references/security-and-compliance` |
| `/hosting/maintenance-and-reliability` | `/references/security-and-compliance` |
| `/tutorials/migrations/banana/overview` | `/serverless/overview` |
| `/docs` | `/get-started` |
| `/quickstart` | `/get-started` |
| `/docs/serverless-endpoint-urls` | `/serverless/endpoints/send-requests` |
| `/docs/using-your-api` | `/serverless/endpoints/send-requests` |
| `/tutorials/integrate-serverless-with-web-applications` | `/serverless/endpoints/send-requests` |
| `/tutorials/text-to-video-pipeline` | `/tutorials/public-endpoints/text-to-video-pipeline` |
| `/ai-endpoints/image-based/dreambooth-sd-v1.5` | `/public-endpoints/overview` |
| `/serverless-ai/runpod-apis` | `/public-endpoints/overview` |
| `/reference/runpod-apis` | `/public-endpoints/overview` |
| `/reference/pygmalion-6b` | `/public-endpoints/overview` |
| `/scaling` | `/serverless/endpoints/endpoint-configurations` |
| `/serverless/timeout` | `/serverless/endpoints/endpoint-configurations` |
| `/templates` | `/pods/templates/overview` |
| `/model-management` | `/serverless/endpoints/model-caching` |
| `/category/workers` | `/serverless/workers/overview` |
| `/api/errors` | `/api-reference/overview` |
| `/docker/create` | `/tutorials/introduction/containers/create-dockerfiles` |
| `/secrets` | `/pods/templates/secrets` |
| `/serverless-gpu/overview` | `/serverless/overview` |
| `/serverless-ai/custom-apis` | `/serverless/overview` |
| `/docs/custom-apis` | `/serverless/overview` |
| `/inference/llm/vllm` | `/serverless/vllm/overview` |
| `/serverless/deploy-with-vllm` | `/serverless/vllm/overview` |
| `/serverless-workers/vllm` | `/serverless/vllm/overview` |
| `/category/vllm-endpoint` | `/serverless/vllm/overview` |
| `/references/runpodctl/runpodctl_start_pod` | `/runpodctl/reference/runpodctl-pod` |
| `/logging` | `/serverless/development/logs` |
| `/docs/pods` | `/pods/overview` |
| `/pricing/serverless` | `/serverless/pricing` |
| `/docs/automatic-stop` | `/pods/manage-pods` |
| `/tutorials/run-ollama-on-pods` | `/tutorials/pods/run-ollama` |
| `/serverless/handler-api` | `/serverless/workers/handler-functions` |
| `/docs/handler-additional-controls` | `/serverless/workers/handler-functions` |
| `/serverless-endpoints` | `/serverless/endpoints/overview` |
| `/serverless/endpoints/get-job-status` | `/serverless/endpoints/operation-reference` |
| `/docs/network-volumes` | `/storage/network-volumes` |
| `/tutorials/deploy-cached-models` | `/tutorials/serverless/model-caching-text` |
| `/docs/errors` | `/serverless/troubleshooting` |
| `/docs/docker` | `/containers` |
| `/docs/connect-to-pod` | `/pods/connect-to-a-pod` |
| `/deployment-guide` | `/serverless/workers/deploy` |
| `/docs/volume-mounts` | `/pods/storage/types` |

Mapping notes:

- Hosting paths follow the existing precedent: `hosting/*` was consolidated into `hosting/partner-requirements`, which already redirects to `/references/security-and-compliance`.
- `/docs/start-pod` was the old GraphQL "Start On-Demand Pod" page (verified via Wayback); `/sdks/graphql/manage-pods` documents the `podResume` mutation.
- `/graphql/spec` points to `/sdks/graphql/manage-pods` rather than `/references/graphql-spec` because the latter is an external-link nav entry (returns 307 to graphql-spec.runpod.io), not a page, and destinations must be final pages.
- `/serverless/endpoints/get-job-status` points to `/serverless/endpoints/operation-reference` (documents the `/status` operation) instead of `/serverless/endpoints/operations`, because `/serverless/endpoints/operations` is itself a redirect source in `docs.json`.
- `/faq` and `/docs/faq` point to `/get-started/concepts`. Note the existing `/references/faq` redirect points to `/pods/troubleshooting/zero-gpus`; concepts is a better general-FAQ landing, but flag if you would rather keep all three consistent.

## Intentionally left to 404

No plausible current content equivalent exists for these; redirecting them anywhere would mislead:

- `/pods/monitoring/prometheus` (no Prometheus/monitoring docs exist today)
- `/resource-management` (topic unidentifiable; never archived, no trace in repo history)
- `/references/region-availability` (no current page lists regions/data centers)
- `/gpu-memory-management` (no current GPU memory/OOM docs; `serverless/development/optimization` covers cold starts, not memory)

## Verification

- `docs.json` parses as valid JSON; no duplicate sources across all 171 redirect entries.
- All 52 destinations returned HTTP 200 on https://docs.runpod.io today; none is a redirect source (one hop only).
- `node scripts/validate-tooltips.js` passes.

Merge gotcha: branch protection requires an ACTIVE Mintlify staging deployment, which any other branch's preview deploy invalidates. Approve and squash-merge in one sitting right after checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
