### PR TITLE
Add redirects for 51 Ahrefs legacy docs 404s

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1296,6 +1296,210 @@
     {
       "source": "/tutorials/integrate-serverless-with-web-applications",
       "destination": "/serverless/endpoints/send-requests"
+    },
+    {
+      "source": "/api/authentication",
+      "destination": "/get-started/api-keys"
+    },
+    {
+      "source": "/category/development",
+      "destination": "/serverless/development/overview"
+    },
+    {
+      "source": "/category/templates",
+      "destination": "/pods/templates/overview"
+    },
+    {
+      "source": "/cli/reference",
+      "destination": "/runpodctl/overview"
+    },
+    {
+      "source": "/configuration",
+      "destination": "/get-started"
+    },
+    {
+      "source": "/docs/comfyui",
+      "destination": "/tutorials/pods/comfyui"
+    },
+    {
+      "source": "/docs/community",
+      "destination": "/community-solutions/overview"
+    },
+    {
+      "source": "/docs/inference-overview",
+      "destination": "/serverless/overview"
+    },
+    {
+      "source": "/docs/network-optimization",
+      "destination": "/serverless/development/optimization"
+    },
+    {
+      "source": "/docs/pod-env-variables",
+      "destination": "/pods/templates/environment-variables"
+    },
+    {
+      "source": "/docs/savings-plans",
+      "destination": "/pods/pricing"
+    },
+    {
+      "source": "/docs/scaling",
+      "destination": "/serverless/endpoints/endpoint-configurations"
+    },
+    {
+      "source": "/docs/serverless-ai",
+      "destination": "/serverless/overview"
+    },
+    {
+      "source": "/docs/template-creation",
+      "destination": "/pods/templates/create-custom-template"
+    },
+    {
+      "source": "/docs/templates",
+      "destination": "/pods/templates/overview"
+    },
+    {
+      "source": "/docs/testing-your-apis-response-time",
+      "destination": "/serverless/development/benchmarking"
+    },
+    {
+      "source": "/docs/troubleshooting",
+      "destination": "/serverless/troubleshooting"
+    },
+    {
+      "source": "/docs/worker-image-creation",
+      "destination": "/serverless/workers/create-dockerfile"
+    },
+    {
+      "source": "/gpu-memory-management",
+      "destination": "/serverless/troubleshooting#oom-errors"
+    },
+    {
+      "source": "/graphql/overview",
+      "destination": "/sdks/graphql/configurations"
+    },
+    {
+      "source": "/network-latency",
+      "destination": "/pods/networking"
+    },
+    {
+      "source": "/pods/container-runtime",
+      "destination": "/tutorials/introduction/containers"
+    },
+    {
+      "source": "/pods/custom-containers/overview",
+      "destination": "/pods/templates/create-custom-template"
+    },
+    {
+      "source": "/pods/network-volumes",
+      "destination": "/storage/network-volumes"
+    },
+    {
+      "source": "/pods/settings/persistent-storage",
+      "destination": "/pods/storage/types"
+    },
+    {
+      "source": "/pods/storage/network-storage",
+      "destination": "/storage/network-volumes"
+    },
+    {
+      "source": "/pricing",
+      "destination": "/pods/pricing"
+    },
+    {
+      "source": "/pricing/network-egress",
+      "destination": "/accounts-billing/billing"
+    },
+    {
+      "source": "/reference/create-pod",
+      "destination": "/api-reference/pods/POST/pods"
+    },
+    {
+      "source": "/reference/faster-whisper",
+      "destination": "/serverless/endpoints/overview"
+    },
+    {
+      "source": "/reference/kandinsky-21",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/references/region-availability",
+      "destination": "/pods/choose-a-pod"
+    },
+    {
+      "source": "/resource-management",
+      "destination": "/pods/choose-a-pod"
+    },
+    {
+      "source": "/sdks/overview",
+      "destination": "/serverless/sdks"
+    },
+    {
+      "source": "/sdks/python",
+      "destination": "/serverless/sdks"
+    },
+    {
+      "source": "/secure-cloud",
+      "destination": "/pods/choose-a-pod#secure-cloud-vs-community-cloud"
+    },
+    {
+      "source": "/serverless-ai/custom-apis/autoscaling",
+      "destination": "/serverless/endpoints/endpoint-configurations"
+    },
+    {
+      "source": "/serverless-ai/custom-apis/using-your-api",
+      "destination": "/serverless/endpoints/send-requests"
+    },
+    {
+      "source": "/serverless-gpus/custom-apis/using-your-api",
+      "destination": "/serverless/endpoints/send-requests"
+    },
+    {
+      "source": "/serverless/endpoints/create-endpoint",
+      "destination": "/serverless/quickstart"
+    },
+    {
+      "source": "/serverless/endpoints/manage",
+      "destination": "/serverless/endpoints/endpoint-configurations"
+    },
+    {
+      "source": "/serverless/endpoints/optimization",
+      "destination": "/serverless/development/optimization"
+    },
+    {
+      "source": "/serverless/endpoints/scaling",
+      "destination": "/serverless/endpoints/endpoint-configurations"
+    },
+    {
+      "source": "/serverless/serverless-endpoints",
+      "destination": "/serverless/endpoints/overview"
+    },
+    {
+      "source": "/serverless/templates",
+      "destination": "/serverless/endpoints/overview"
+    },
+    {
+      "source": "/serverless/vllm-measurements",
+      "destination": "/serverless/development/benchmarking"
+    },
+    {
+      "source": "/serverless/worker",
+      "destination": "/serverless/workers/overview"
+    },
+    {
+      "source": "/serverless/workers/flashboot",
+      "destination": "/serverless/endpoints/endpoint-configurations#flashboot"
+    },
+    {
+      "source": "/serverless/workers/get-started",
+      "destination": "/serverless/quickstart"
+    },
+    {
+      "source": "/tutorials/build-a-chatbot-with-gemma-3",
+      "destination": "/tutorials/serverless/run-gemma-7b"
+    },
+    {
+      "source": "/tutorials/build-docker-images-with-bazel",
+      "destination": "/tutorials/pods/build-docker-images"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add 51 high-confidence redirects for legacy docs URLs in the July 16 Ahrefs 4XX report
- route old API, Serverless, Pod, SDK, pricing, and tutorial paths to their current equivalents
- preserve true 404s where there is no trustworthy replacement

## Validation

- parsed `docs.json` successfully
- confirmed no duplicate redirect sources
- confirmed every local redirect destination maps to a tracked MDX file
- confirmed all 35 unique destinations return HTTP 200 on published docs
- ran `node scripts/validate-tooltips.js` successfully
- ran `git diff --check` successfully

## Intentionally not redirected

- `/404.html`, expected not-found route
- `/pods/monitoring/prometheus`, no current equivalent
- `/tutorials/pods/run-fooocus`, no current equivalent

Source: Ahrefs Site Audit project 3648513, crawl 2026-07-16T19:44:53Z, issue `4XX page`.