### PR TITLE
Fix Ahrefs internal redirect links

### DIFF
--- a/community-solutions/runpod-network-volume-storage-tool.mdx
+++ b/community-solutions/runpod-network-volume-storage-tool.mdx
@@ -7,7 +7,7 @@ icon: "floppy-disk"
 
 GitHub repository: [github.com/justinwlin/Runpod-Network-Volume-Storage-Tool](https://github.com/justinwlin/Runpod-Network-Volume-Storage-Tool)
 
-Runpod provides an [S3-compatible layer](/serverless/storage/s3-api) for network volumes, enabling object storage operations on your network storage. This community tool makes it easy to interact with that S3 layer through three interfaces: a command-line interface, a Python SDK for programmatic access, and a self-hosted REST API server for integration with other applications.
+Runpod provides an [S3-compatible layer](/storage/s3-api) for network volumes, enabling object storage operations on your network storage. This community tool makes it easy to interact with that S3 layer through three interfaces: a command-line interface, a Python SDK for programmatic access, and a self-hosted REST API server for integration with other applications.
 
 ## Requirements
 

--- a/containers.mdx
+++ b/containers.mdx
@@ -9,7 +9,7 @@ Learn how to build and deploy applications on the Runpod platform with this set 
 
 </Card>
 
-<Card href="/tutorials/introduction/containers/" horizontal>
+<Card href="/tutorials/introduction/containers" horizontal>
 ## 📄️ Intro to containers
 
 Discover the world of containerization with Docker, a platform for isolated environments that package applications, frameworks, and libraries into self-contained containers for consistent and reliable deployment across diverse computing environments.

--- a/docs.json
+++ b/docs.json
@@ -590,7 +590,8 @@
   },
   "logo": {
     "dark": "/logo/runpod-logo-white.svg",
-    "light": "/logo/runpod-logo-black.svg"
+    "light": "/logo/runpod-logo-black.svg",
+    "href": "/overview"
   },
   "navbar": {
     "links": [

--- a/flash/apps/apps-and-environments.mdx
+++ b/flash/apps/apps-and-environments.mdx
@@ -85,7 +85,7 @@ Environments can be in several states:
 |-------|-------------|
 | `deploying` | Deployment in progress (building artifacts, provisioning endpoints) |
 | `deployed` | Successfully deployed and running |
-| `failed` | Deployment failed (check logs in the [Runpod console](https://www.runpod.io/console/serverless)) |
+| `failed` | Deployment failed (check logs in the [Runpod console](https://console.runpod.io/serverless)) |
 | `updating` | Configuration update in progress |
 
 ## Builds and deployments

--- a/flash/apps/build-app.mdx
+++ b/flash/apps/build-app.mdx
@@ -12,7 +12,7 @@ If you haven't already, we recommend starting with the [Quickstart](/flash/quick
 
 ## Requirements:
 
-- You've [created a Runpod account](/get-started/manage-accounts).
+- You've [created a Runpod account](/accounts-billing/manage-accounts).
 - You've [created a Runpod API key](/get-started/api-keys).
 - You've installed [Python 3.10, 3.11, 3.12, or 3.13](https://www.python.org/downloads/).
 

--- a/flash/apps/requests.mdx
+++ b/flash/apps/requests.mdx
@@ -247,7 +247,7 @@ output = run_request.output()  # Get result once complete
 result = endpoint.run_sync({"prompt": "Hello world"})
 ```
 
-See the [Runpod SDK documentation](/sdks/python/endpoints) for complete SDK usage.
+See the [Runpod SDK documentation](/serverless/endpoints/send-requests) for complete SDK usage.
 
 ## Next steps
 
@@ -258,7 +258,7 @@ See the [Runpod SDK documentation](/sdks/python/endpoints) for complete SDK usag
   <Card title="Configuration reference" href="/flash/configuration/parameters" icon="layer-group" horizontal>
     View all endpoint configuration parameters.
   </Card>
-  <Card title="Runpod SDK" href="/sdks/python/endpoints" icon="code" horizontal>
+  <Card title="Runpod SDK" href="/serverless/endpoints/send-requests" icon="code" horizontal>
     Use the Python SDK for programmatic access.
   </Card>
 </CardGroup>

--- a/flash/cli/login.mdx
+++ b/flash/cli/login.mdx
@@ -67,7 +67,7 @@ Or add it to your project's `.env` file for local CLI use:
 RUNPOD_API_KEY=your_api_key_here
 ```
 
-Generate an API key from [Settings > API Keys](https://www.runpod.io/console/user/settings) in the Runpod console.
+Generate an API key from [Settings > API Keys](https://console.runpod.io/user/settings) in the Runpod console.
 
 ## Credential resolution priority
 

--- a/flash/configuration/parameters.mdx
+++ b/flash/configuration/parameters.mdx
@@ -39,7 +39,7 @@ This page provides a complete reference for all parameters available on the `End
 **Type**: `str`
 **Required**: Yes (unless `id=` is specified)
 
-The endpoint name visible in the [Runpod console](https://www.runpod.io/console/serverless). Use descriptive names to easily identify endpoints.
+The endpoint name visible in the [Runpod console](https://console.runpod.io/serverless). Use descriptive names to easily identify endpoints.
 
 ```python
 @Endpoint(name="ml-inference-prod", gpu=GpuGroup.ANY)

--- a/flash/custom-docker-images.mdx
+++ b/flash/custom-docker-images.mdx
@@ -264,7 +264,7 @@ await job.cancel()           # Cancel the job
 - Verify your Docker image is compatible with [Runpod Serverless](/serverless/overview).
 - Check environment variables are correct.
 - Ensure the image includes a valid handler function.
-- Check worker logs in the [Runpod console](https://www.runpod.io/console/serverless).
+- Check worker logs in the [Runpod console](https://console.runpod.io/serverless).
 
 ### Out of memory errors
 
@@ -282,7 +282,7 @@ await job.cancel()           # Cancel the job
 
 **Solutions**:
 - Add `HF_TOKEN` to `env` for Hugging Face gated models.
-- Configure Docker registry authentication in [Runpod console](https://www.runpod.io/console/user/settings) for private images.
+- Configure Docker registry authentication in [Runpod console](https://console.runpod.io/user/settings) for private images.
 
 ## Next steps
 

--- a/flash/pricing.mdx
+++ b/flash/pricing.mdx
@@ -105,7 +105,7 @@ def process(data): ...
 
 ### Monitoring costs
 
-Monitor your usage in the [Runpod console](https://www.runpod.io/console/serverless) to track:
+Monitor your usage in the [Runpod console](https://console.runpod.io/serverless) to track:
 
 - Total compute time across endpoints.
 - Worker utilization and idle time.

--- a/flash/quickstart.mdx
+++ b/flash/quickstart.mdx
@@ -8,7 +8,7 @@ This quickstart gets you running GPU workloads on Runpod in minutes. You'll exec
 
 ## Requirements
 
-- [Runpod account](/get-started/manage-accounts) with a verified email address.
+- [Runpod account](/accounts-billing/manage-accounts) with a verified email address.
 - [An API key](/get-started/api-keys) with **All** access permissions to your Runpod account.
 - [Python 3.10, 3.11, 3.12, or 3.13](https://www.python.org/downloads/) installed.
 - [uv](https://docs.astral.sh/uv/) installed.
@@ -141,7 +141,7 @@ If you're having authorization issues, you can set your API key directly in your
 export RUNPOD_API_KEY="your_key"
 ```
 
-Replace `your_key` with your actual API key from the [Runpod console](https://www.runpod.io/console/user/settings).
+Replace `your_key` with your actual API key from the [Runpod console](https://console.runpod.io/user/settings).
 </Tip>
 
 ## Step 5: Update and run again
@@ -214,7 +214,7 @@ def gpu_matrix_multiply(size):
 
 The `@Endpoint` decorator configures everything in one place:
 
-- **`name`**: Identifies your endpoint in the [Runpod console](https://www.runpod.io/console/serverless).
+- **`name`**: Identifies your endpoint in the [Runpod console](https://console.runpod.io/serverless).
 - **`gpu`**: Which GPU to use (`GpuGroup.ANY` accepts any available GPU for faster provisioning).
 - **`workers`**: Maximum parallel workers (allows 3 concurrent executions).
 - **`idle_timeout`**: Seconds a worker stays active after completing a request before scaling down. Setting this to 300 (5 minutes) gives you more time to iterate on your code while the worker remains warm.
@@ -413,7 +413,7 @@ def gpu_matrix_multiply(size):
     ...
 ```
 
-You can also check [GPU availability](https://www.runpod.io/console/serverless) in the console.
+You can also check [GPU availability](https://console.runpod.io/serverless) in the console.
 
 ### Import errors
 

--- a/flash/troubleshooting.mdx
+++ b/flash/troubleshooting.mdx
@@ -32,7 +32,7 @@ Available levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`.
 
 ### Runpod console
 
-View detailed metrics and logs in the [Runpod console](https://www.runpod.io/console/serverless):
+View detailed metrics and logs in the [Runpod console](https://console.runpod.io/serverless):
 
 1. Navigate to the **Serverless** section.
 2. Click on your endpoint to view:
@@ -46,7 +46,7 @@ The console provides metrics including request rate, queue depth, latency, worke
 
 Access detailed logs for specific workers:
 
-1. Go to the [Serverless console](https://www.runpod.io/console/serverless).
+1. Go to the [Serverless console](https://console.runpod.io/serverless).
 2. Select your endpoint.
 3. Click on a worker to view its logs.
 
@@ -88,7 +88,7 @@ Get a key: https://docs.runpod.io/get-started/api-keys
 
 **Solution:**
 
-1. Generate an API key from [Settings > API Keys](https://www.runpod.io/console/user/settings) in the Runpod console. The key needs **All** access permissions.
+1. Generate an API key from [Settings > API Keys](https://console.runpod.io/user/settings) in the Runpod console. The key needs **All** access permissions.
 
 2. Authenticate using one of these methods:
 
@@ -343,7 +343,7 @@ Endpoint URL not available - endpoint may not be deployed
 
 2. **For Flash apps**: Deploy the app first with `flash deploy`, then call the endpoint.
 
-3. **Check endpoint status**: View your endpoints in the [Serverless console](https://www.runpod.io/console/serverless).
+3. **Check endpoint status**: View your endpoints in the [Serverless console](https://console.runpod.io/serverless).
 
 ### Execution timeout
 
@@ -382,7 +382,7 @@ Failed to connect to endpoint [name] ([url])
 
 1. **Check internet connection**: Verify you have network access.
 2. **Retry**: Transient network issues often resolve on retry. Flash includes automatic retry logic.
-3. **Check endpoint status**: Verify the endpoint is running in the [Serverless console](https://www.runpod.io/console/serverless).
+3. **Check endpoint status**: Verify the endpoint is running in the [Serverless console](https://console.runpod.io/serverless).
 
 ### HTTP errors from endpoint
 
@@ -395,7 +395,7 @@ HTTP error from endpoint [name]: 500 - Internal Server Error
 
 **Solutions:**
 
-1. **Check logs**: View worker logs in the [Serverless console](https://www.runpod.io/console/serverless) for detailed error messages.
+1. **Check logs**: View worker logs in the [Serverless console](https://console.runpod.io/serverless) for detailed error messages.
 
 2. **Test locally**: Use `flash dev` to test your function locally before deploying.
 
@@ -519,7 +519,7 @@ Circuit breaker is open. Retry in [N] seconds
    gpu=GpuGroup.ANY
    ```
 
-3. **Check availability**: View GPU availability in the [Serverless console](https://www.runpod.io/console/serverless).
+3. **Check availability**: View GPU availability in the [Serverless console](https://console.runpod.io/serverless).
 
 4. **Contact support**: For guaranteed capacity, contact [Runpod support](https://www.runpod.io/contact).
 

--- a/flash/windows-wsl2.mdx
+++ b/flash/windows-wsl2.mdx
@@ -10,7 +10,7 @@ Flash runs natively on macOS and Linux. On Windows, you can run Flash through Wi
 
 - Windows 10 version 2004 or later, or Windows 11.
 - Administrator access to your Windows machine.
-- [Runpod account](/get-started/manage-accounts) with a verified email address.
+- [Runpod account](/accounts-billing/manage-accounts) with a verified email address.
 - [An API key](/get-started/api-keys) with **All** access permissions.
 
 ## Step 1: Enable WSL2

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -341,7 +341,7 @@ runpodctl pod delete $RUNPOD_POD_ID
   <Card title="Generate API keys" href="/get-started/api-keys" icon="key" horizontal>
     Create API keys for programmatic resource management.
   </Card>
-  <Card title="Manage your account" href="/get-started/manage-accounts" icon="users" horizontal>
+  <Card title="Manage your account" href="/accounts-billing/manage-accounts" icon="users" horizontal>
     Create teams and invite collaborators.
   </Card>
   <Card title="Choose the right Pod" href="/pods/choose-a-pod" icon="server" horizontal>

--- a/get-started/connect-to-runpod.mdx
+++ b/get-started/connect-to-runpod.mdx
@@ -29,7 +29,7 @@ The Runpod REST API allows you to programmatically manage and control compute re
 
 Runpod provides SDKs in Python, JavaScript, Go, and GraphQL to help you integrate Runpod services into your applications.
 
-[Explore the SDKs →](/sdks/python/overview)
+[Explore the SDKs →](/serverless/sdks)
 
 ## Command-line interface (CLI)
 

--- a/hub/publishing-guide.mdx
+++ b/hub/publishing-guide.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Hub publishing guide"
 description: "Publish your repositories to the Runpod Hub."
 ---
 
-Learn how to publish your repositories to the [Runpod Hub](https://www.runpod.io/console/hub), including how to configure your repository with the required `hub.json` and `tests.json` files.
+Learn how to publish your repositories to the [Runpod Hub](https://console.runpod.io/hub), including how to configure your repository with the required `hub.json` and `tests.json` files.
 
 After you publish your repository to the Hub, you can start [earning revenue](/hub/revenue-sharing) from your users' compute usage.
 

--- a/instant-clusters/slurm-clusters.mdx
+++ b/instant-clusters/slurm-clusters.mdx
@@ -92,4 +92,4 @@ If you encounter issues with your Slurm Cluster, try the following:
 - **Jobs stuck in pending state:** Check resource availability with `sinfo` and ensure requested resources are available. If you need more resources, you can add more nodes to your cluster.
 - **Authentication errors:** Munge is pre-configured, but if issues arise, verify the munge service is running on all nodes.
 
-For additional support, contact [Runpod support](https://contact.runpod.io/) with your cluster ID and specific error messages.
+For additional support, contact [Runpod support](https://contact.runpod.io/hc/en-us) with your cluster ID and specific error messages.

--- a/integrations/n8n-integration.mdx
+++ b/integrations/n8n-integration.mdx
@@ -28,7 +28,7 @@ In this tutorial, you'll learn how to:
 
 Before you begin, you'll need:
 
-* A [Runpod account](/get-started/manage-accounts) (with available credits).
+* A [Runpod account](/accounts-billing/manage-accounts) (with available credits).
 * A [Runpod API key](/get-started/api-keys).
 * An [n8n](https://n8n.io/) account.
 

--- a/pods/configuration/connect-to-ide.mdx
+++ b/pods/configuration/connect-to-ide.mdx
@@ -45,7 +45,7 @@ Before you can connect to a Pod, you'll need an SSH key that is paired with your
     ssh-ed25519 AAAAC4NzaC1lZDI1JTE5AAAAIGP+L8hnjIcBqUb8NRrDiC32FuJBvRA0m8jLShzgq6BQ YOUR_EMAIL@DOMAIN.COM
     ```
 
-3.  Copy and paste the output into the **SSH Public Keys** field in your [Runpod user account settings](https://www.runpod.io/console/user/settings).
+3.  Copy and paste the output into the **SSH Public Keys** field in your [Runpod user account settings](https://console.runpod.io/user/settings).
 
 <Warning>
 To enable SSH access, your public key must be present in the `~/.ssh/authorized_keys` file on your Pod. If you upload your public key to the settings page before your Pod starts, the system will automatically inject it into that file at startup.
@@ -76,7 +76,7 @@ Next, you'll configure SSH access to your Pod using the Remote-SSH extension. Th
 <Tabs>
 
   <Tab title="VSCode">
-   1. From the [Pods](https://www.runpod.io/console/pods) page, select the Pod you deployed.
+   1. From the [Pods](https://console.runpod.io/pods) page, select the Pod you deployed.
    2. Select **Connect**, then select the **SSH** tab.
    3. Copy the second command, under **SSH over exposed TCP**. It will look similar to this:
    
@@ -95,7 +95,7 @@ Next, you'll configure SSH access to your Pod using the Remote-SSH extension. Th
 
   <Tab title="Cursor">
 
-1. From the [Pods](https://www.runpod.io/console/pods) page, select the Pod you deployed.
+1. From the [Pods](https://console.runpod.io/pods) page, select the Pod you deployed.
 
 2. Select **Connect**.
 3. Under **Direct TCP Ports**, look for a line similar to:

--- a/pods/manage-pods.mdx
+++ b/pods/manage-pods.mdx
@@ -141,7 +141,7 @@ curl --request POST \
 
 ## Start a Pod
 
-Resume a stopped Pod. Note: You may be allocated [zero GPUs](/references/troubleshooting/zero-gpus) if capacity has changed.
+Resume a stopped Pod. Note: You may be allocated [zero GPUs](/pods/troubleshooting/zero-gpus) if capacity has changed.
 
 <Tabs>
 <Tab title="Web">
@@ -253,7 +253,7 @@ Access logs from the [Pods page](https://www.console.runpod.io/pods) by expandin
 
 | Issue | Solution |
 |-------|----------|
-| **Zero GPUs on restart** | See [Zero GPU Pods](/references/troubleshooting/zero-gpus) |
+| **Zero GPUs on restart** | See [Zero GPU Pods](/pods/troubleshooting/zero-gpus) |
 | **Pod stuck initializing** | Check logs for command errors; ensure you have an idle job (e.g., `sleep infinity`) if using SSH |
 | **Docker Compose not working** | Not supported. Use a [custom template](/pods/templates/overview) with your dependencies baked in. |
 

--- a/pods/storage/cloud-sync.mdx
+++ b/pods/storage/cloud-sync.mdx
@@ -52,7 +52,7 @@ Follow the steps below to sync your data with Amazon S3:
   </Step>
 
    <Step title="Sync your data with Runpod">
-    In the Runpod console, navigate to the [Pods page](https://runpod.io/console/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **AWS S3** from the available providers.
+    In the Runpod console, navigate to the [Pods page](https://console.runpod.io/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **AWS S3** from the available providers.
 
     Enter your **AWS Access Key ID** and **Secret Access Key** in the provided fields. Specify the **AWS Region** where your bucket is located and provide the complete bucket path where you want to store your data. 
     
@@ -82,7 +82,7 @@ Follow the steps below to sync your data with Google Cloud Storage:
   </Step>
 
   <Step title="Sync your data with Runpod">
-    In the Runpod console, navigate to the [Pods page](https://runpod.io/console/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **Google Cloud Storage** from the available providers.
+    In the Runpod console, navigate to the [Pods page](https://console.runpod.io/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **Google Cloud Storage** from the available providers.
 
     Paste the entire contents of your Service Account JSON key into the provided field. Specify the source/destination path within your bucket and select which folders from your Pod to transfer.
 
@@ -115,7 +115,7 @@ Follow the steps below to sync your data with Microsoft Azure Blob Storage:
   </Step>
 
   <Step title="Sync your data with Runpod">
-    In the Runpod console, navigate to the [Pods page](https://runpod.io/console/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **Azure Blob Storage** from the available providers.
+    In the Runpod console, navigate to the [Pods page](https://console.runpod.io/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **Azure Blob Storage** from the available providers.
 
     Enter your **Azure Account Name** and **Account Key** in the provided fields. Specify the source/destination path in your blob storage where you want to store your data.
 
@@ -143,7 +143,7 @@ Follow the steps below to sync your data with Backblaze B2 Cloud Storage:
   </Step>
 
   <Step title="Sync your data with Runpod">
-    In the Runpod console, navigate to the [Pods page](https://runpod.io/console/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **Backblaze B2** from the available providers.
+    In the Runpod console, navigate to the [Pods page](https://console.runpod.io/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **Backblaze B2** from the available providers.
 
     Enter your **Backblaze B2 Account ID**, **Application Key**, and **bucket path** as shown in the Backblaze interface.
 
@@ -176,7 +176,7 @@ Follow the steps below to sync your data with Dropbox:
   </Step>
 
   <Step title="Sync your data with Runpod">
-    In the Runpod console, navigate to the [Pods page](https://runpod.io/console/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **Dropbox** from the available providers.
+    In the Runpod console, navigate to the [Pods page](https://console.runpod.io/pods) and select the Pod containing your data. Click **Cloud Sync**, then select **Dropbox** from the available providers.
 
     Paste your **Dropbox Access Token** and specify the remote path where you want to store the data. Creating a dedicated folder in Dropbox beforehand helps with organization.
 

--- a/pods/storage/create-network-volumes.mdx
+++ b/pods/storage/create-network-volumes.mdx
@@ -113,7 +113,7 @@ Runpod provides an S3-compatible API that allows you to access and manage files 
 
 The S3-compatible API supports standard S3 operations including file uploads, downloads, listing, and deletion. You can use it with popular tools like the AWS CLI and Boto3 (Python).
 
-For detailed setup instructions, authentication, and usage examples, see the [S3-compatible API documentation](/serverless/storage/s3-api).
+For detailed setup instructions, authentication, and usage examples, see the [S3-compatible API documentation](/storage/s3-api).
 
 <Note>
 The S3-compatible API is currently available for network volumes in the following datacenters: `EUR-IS-1`, `EU-RO-1`, `EU-CZ-1`, `US-KS-2`, `US-CA-2`.
@@ -129,7 +129,7 @@ Using network volumes provides significant flexibility that can lead to cost sav
 
 Network volume storage space costs less than for volume disks (\$0.07/GB/month rather than \$0.10/GB/month), and storing data on a network volume can save you money compared to provisioning separate disk space for multiple Pods (even with just two Pods sharing one volume).
 
-For a deeper dive into potential benefits, read this [blog article on network volumes](https://blog.runpod.io/four-reasons-to-set-up-a/).
+For a deeper dive into potential benefits, read this [blog article on network volumes](https://www.runpod.io/blog/network-volumes-on-runpod-secure-cloud).
 
 ## Migrate files between volumes
 

--- a/pods/templates/create-custom-template.mdx
+++ b/pods/templates/create-custom-template.mdx
@@ -18,7 +18,7 @@ By creating custom templates, you can package everything your project needs into
 
 Before you begin, you'll need:
 
-- A [Runpod account](/get-started/manage-accounts).
+- A [Runpod account](/accounts-billing/manage-accounts).
 - Docker installed on your local machine or a remote server.
 - A Docker Hub account (or access to another container registry).
 - Basic familiarity with Docker and Python.

--- a/pods/templates/manage-templates.mdx
+++ b/pods/templates/manage-templates.mdx
@@ -122,7 +122,7 @@ Environment variables are particularly useful for:
 
 ### Runpod system environment variables
 
-Runpod automatically provides several [predefined environment variables](/pods/references/environment-variables) in every Pod, for example:
+Runpod automatically provides several [predefined environment variables](/pods/templates/environment-variables) in every Pod, for example:
 - `RUNPOD_POD_ID`: Unique identifier for your Pod.
 - `RUNPOD_API_KEY`: API key for making Runpod API calls from within the Pod.
 - `RUNPOD_POD_HOSTNAME`: Hostname of the server running your Pod.

--- a/pods/troubleshooting/storage-full.mdx
+++ b/pods/troubleshooting/storage-full.mdx
@@ -101,4 +101,4 @@ ls -d /workspace/.Trash* 2>/dev/null && rm -rf /workspace/.Trash* && echo "✓ C
 
 ## Additional storage
 
-If your Pod needs more than 20GB of storage, consider using a network volume. For more information, see [Network volumes](/storage/network-volumes), or refer to [this blog post](https://blog.runpod.io/four-reasons-to-set-up-a/).
+If your Pod needs more than 20GB of storage, consider using a network volume. For more information, see [Network volumes](/storage/network-volumes), or refer to [this blog post](https://www.runpod.io/blog/network-volumes-on-runpod-secure-cloud).

--- a/public-endpoints/ai-coding-tools.mdx
+++ b/public-endpoints/ai-coding-tools.mdx
@@ -11,7 +11,7 @@ Runpod's [Public Endpoints](/public-endpoints/overview) provide OpenAI-compatibl
 
 Before you start, you'll need:
 
-- A [Runpod account](/get-started/manage-accounts) with an [API key](/get-started/api-keys), and at least \$5 in Runpod credits.
+- A [Runpod account](/accounts-billing/manage-accounts) with an [API key](/get-started/api-keys), and at least \$5 in Runpod credits.
 - One or more of the following AI coding tools installed on your local machine:
   - [OpenCode](https://opencode.ai/): Terminal-based AI coding assistant.
   - [Cursor](https://cursor.sh/): AI-powered code editor.

--- a/public-endpoints/quickstart.mdx
+++ b/public-endpoints/quickstart.mdx
@@ -11,7 +11,7 @@ This quickstart walks you through generating an image using Runpod Public Endpoi
 
 ## Requirements
 
-- A [Runpod account](/get-started/manage-accounts) with at least \$1 in credits
+- A [Runpod account](/accounts-billing/manage-accounts) with at least \$1 in credits
 - A [Runpod API key](/get-started/api-keys)
 
 ## Step 1: Generate an image in the playground

--- a/public-endpoints/requests.mdx
+++ b/public-endpoints/requests.mdx
@@ -8,7 +8,7 @@ This guide covers all the ways to interact with Public Endpoints, from testing i
 
 ## Requirements
 
-- A [Runpod account](/get-started/manage-accounts) with credits
+- A [Runpod account](/accounts-billing/manage-accounts) with credits
 - A [Runpod API key](/get-started/api-keys) for making API requests
 
 ## Use the playground
@@ -28,7 +28,7 @@ The playground offers:
 
 ### Access the playground
 
-1. Navigate to the [Runpod Hub](https://www.runpod.io/console/hub) in the console.
+1. Navigate to the [Runpod Hub](https://console.runpod.io/hub) in the console.
 2. Select the **Public Endpoints** section.
 3. Browse the available models and select one that fits your needs.
 

--- a/references/gpu-types.mdx
+++ b/references/gpu-types.mdx
@@ -5,7 +5,7 @@ mode: "wide"
 ---
 <div className="overview-page-wrapper" />
 
-For information on pricing, see [GPU pricing](https://www.runpod.io/gpu-instance/pricing).
+For information on pricing, see [GPU pricing](https://www.runpod.io/pricing).
 
 ## GPU types
 

--- a/references/security-and-compliance.mdx
+++ b/references/security-and-compliance.mdx
@@ -34,4 +34,4 @@ For lawful transfer of personal data outside the EU, Runpod uses appropriate mec
 
 ## Legal resources
 
-For detailed information about terms, policies, and legal agreements, visit the [Runpod legal page](https://www.runpod.io/legal).
+For detailed information about terms, policies, and legal agreements, visit the [Runpod legal page](https://www.runpod.io/legal/compliance).

--- a/release-notes.mdx
+++ b/release-notes.mdx
@@ -73,7 +73,7 @@ rss: true
 
     <h4><Badge color="green">New Release</Badge> Cost Centers now generally available</h4>
 
-    [Cost Centers](/get-started/manage-accounts) let teams allocate and track GPU spend by project, team, or business unit. Detailed cost breakdowns are now available in billing, and all users receive itemized invoices as of May 1.
+    [Cost Centers](/accounts-billing/manage-accounts) let teams allocate and track GPU spend by project, team, or business unit. Detailed cost breakdowns are now available in billing, and all users receive itemized invoices as of May 1.
 
     <h4><Badge color="blue">Improvement</Badge> New Pod deploy flow with workload-first GPU selection</h4>
 
@@ -88,7 +88,7 @@ rss: true
 
     <h4><Badge color="green">New Release</Badge> Instant Cluster Expansion and Priority FlashBoot now live</h4>
 
-    [Instant Clusters](/instant-clusters/overview) can now expand to more nodes faster. Priority FlashBoot reduces cold-start times for cluster workers. Both features are live with no configuration changes needed. Expanding an existing cluster is currently only available to Runpod admins. To add nodes to an existing cluster, reach out to the Runpod team.
+    [Instant Clusters](/instant-clusters) can now expand to more nodes faster. Priority FlashBoot reduces cold-start times for cluster workers. Both features are live with no configuration changes needed. Expanding an existing cluster is currently only available to Runpod admins. To add nodes to an existing cluster, reach out to the Runpod team.
 
     <h4><Badge color="green">New Release</Badge> FlashBoot for CPU Serverless now in public beta</h4>
 
@@ -204,7 +204,7 @@ Flash now supports deploying endpoints to [multiple datacenters](/flash/configur
 <Accordion title="December 2025">
 ## Pod migration in beta and Serverless development guides
 
-- [Pod migration (beta)](/references/troubleshooting/pod-migration): Migrate your Pod to a new machine when your stopped Pod's GPU is occupied. Provisions a new Pod with the same specifications and automatically transfers your data to an available machine.
+- [Pod migration (beta)](/pods/troubleshooting/pod-migration): Migrate your Pod to a new machine when your stopped Pod's GPU is occupied. Provisions a new Pod with the same specifications and automatically transfers your data to an available machine.
 - [New Serverless development guides](/serverless/overview): We've added a comprehensive new set of guides for developing, testing, and debugging Serverless endpoints.
 
 </Accordion>
@@ -238,7 +238,7 @@ Flash now supports deploying endpoints to [multiple datacenters](/flash/configur
 ## S3-compatible storage and updated referral program
 
 - [S3-compatible API for network volumes](/storage/s3-api): Upload and retrieve files from your network volumes without compute using AWS S3 CLI or Boto3. Integrate Runpod storage into any AI pipeline with zero-config ease and object-level control.
-- [Referral program revamp](/references/referrals): Updated rewards and tiers with clearer dashboards to track performance.
+- [Referral program revamp](/accounts-billing/referrals): Updated rewards and tiers with clearer dashboards to track performance.
 
 </Accordion>
 
@@ -318,7 +318,7 @@ Flash now supports deploying endpoints to [multiple datacenters](/flash/configur
 
 - **US-TX-3 and EUR-IS-1 added to network storage**: Network volumes available in more regions for local persistence.
 - **Runpod slashes GPU prices**: Broad GPU price reductions to lower training and inference total cost of ownership.
-- [Referral program revamp](/references/referrals): Updated commissions and bonuses with an affiliate tier and improved tracking.
+- [Referral program revamp](/accounts-billing/referrals): Updated commissions and bonuses with an affiliate tier and improved tracking.
 
 </Accordion>
 
@@ -386,7 +386,7 @@ Flash now supports deploying endpoints to [multiple datacenters](/flash/configur
 <Accordion title="August 2023">
 ## Team governance, storage expansion, and better debugging
 
-- [Teams](/get-started/manage-accounts): Organization workspaces with role-based access control for Pods, endpoints, and billing.
+- [Teams](/accounts-billing/manage-accounts): Organization workspaces with role-based access control for Pods, endpoints, and billing.
 - [Savings plans](/pods/pricing): Plans surfaced prominently in console with easier purchase and management for steady usage.
 - **Network storage to US-KS-1**: Enable network volumes in US-KS-1 for local, persistent data workflows.
 - [Serverless log view](/serverless/development/logs): Stream worker stdout and stderr in the UI and API for real-time debugging.

--- a/runpodctl/reference/runpodctl-config.mdx
+++ b/runpodctl/reference/runpodctl-config.mdx
@@ -28,7 +28,7 @@ For first-time setup, we recommend using [`runpodctl doctor`](/runpodctl/referen
 ## Flags
 
 <ResponseField name="--apiKey" type="string">
-Your Runpod API key, which authenticates the CLI to access your account. You can generate an API key from the [Runpod console](https://www.runpod.io/console/user/settings).
+Your Runpod API key, which authenticates the CLI to access your account. You can generate an API key from the [Runpod console](https://console.runpod.io/user/settings).
 </ResponseField>
 
 <ResponseField name="--apiUrl" type="string" default="https://api.runpod.io/graphql">

--- a/sdks/graphql/configurations.mdx
+++ b/sdks/graphql/configurations.mdx
@@ -59,4 +59,4 @@ The following fields are commonly used when creating Pods and templates.
 | `ports` | String | Ports to expose, formatted as `port/protocol` (e.g., `8888/http,22/tcp`). |
 | `gpuTypeId` | String | GPU type identifier (e.g., `NVIDIA RTX A6000`). Use the `gpuTypes` query to list available options. |
 | `gpuCount` | Integer | Number of GPUs to allocate. |
-| `containerRegistryAuthId` | String | ID of saved registry credentials for private container images. Find this in your [Runpod settings](https://www.runpod.io/console/user/settings). |
+| `containerRegistryAuthId` | String | ID of saved registry credentials for private container images. Find this in your [Runpod settings](https://console.runpod.io/user/settings). |

--- a/serverless/development/dual-mode-worker.mdx
+++ b/serverless/development/dual-mode-worker.mdx
@@ -13,7 +13,7 @@ To get started quickly, you can [clone this repository](https://github.com/justi
 
 ## Requirements
 
-- You've [created a Runpod account](/get-started/manage-accounts).
+- You've [created a Runpod account](/accounts-billing/manage-accounts).
 - You've installed [Python 3.x](https://www.python.org/downloads/) and [Docker](https://docs.docker.com/get-started/get-docker/) and configured them for your command line.
 - Basic understanding of Docker concepts and shell scripting.
 
@@ -307,7 +307,7 @@ Now that you've finished building our Docker image, let's explore how you would 
 
 Deploy the image to a Pod by following these steps:
 
-1. Navigate to the [Pods page](https://www.runpod.io/console/pods) in the Runpod console.
+1. Navigate to the [Pods page](https://console.runpod.io/pods) in the Runpod console.
 2. Click **Deploy**.
 3. Select your preferred GPU.
 4. Under **Container Image**, enter `YOUR_USERNAME/dual-mode-worker:latest`.
@@ -326,7 +326,7 @@ Once your Pod is running, you can:
 
 Once you're confident with your `handler.py` logic tested in Pod mode, you're ready to deploy your dual-mode worker to a Serverless endpoint.
 
-1. Navigate to the [Serverless page](https://www.runpod.io/console/serverless) in the Runpod console.
+1. Navigate to the [Serverless page](https://console.runpod.io/serverless) in the Runpod console.
 2. Click **New Endpoint**.
 3. Click **Import from Docker Registry**.
 4. In the **Container Image** field, enter your Docker image URL: `docker.io/YOUR_USERNAME/dual-mode-worker:latest`, then click *Next****.

--- a/serverless/development/environment-variables.mdx
+++ b/serverless/development/environment-variables.mdx
@@ -13,7 +13,7 @@ Environment variables are set in the Runpod console and are available to your ha
 
 You can set environment variables in the Runpod console when [creating or editing your endpoint](/serverless/endpoints/overview):
 
-1. Navigate to your endpoint in the [Runpod console](https://www.runpod.io/console/serverless).
+1. Navigate to your endpoint in the [Runpod console](https://console.runpod.io/serverless).
 2. Click on the **Settings** tab.
 3. Scroll to the **Environment Variables** section.
 4. Add your variables as key-value pairs.

--- a/serverless/development/logs.mdx
+++ b/serverless/development/logs.mdx
@@ -23,7 +23,7 @@ Endpoint logs are automatically collected from your worker instances and streame
 - **Standard output (stdout)** from your handler functions.
 - **Standard error (stderr)** from your applications.
 - **System messages** related to worker lifecycle events.
-- **Framework logs** from the Runpod SDK. To learn more about the Runpod logging library, see the [Runpod SDK documentation](/tutorials/sdks/python/101/error).
+- **Framework logs** from the Runpod SDK. To learn more about the Runpod logging library, see the [Runpod SDK documentation](/serverless/workers/handler-functions).
 
 Logs are streamed in near real-time with only a few seconds of lag. 
 

--- a/serverless/endpoints/model-caching.mdx
+++ b/serverless/endpoints/model-caching.mdx
@@ -113,7 +113,7 @@ Once it's deployed, your workers will all have access to the cached model for <I
 
 When using [vLLM workers](/serverless/vllm/overview) or other official Runpod worker images, you can usually just set the **Model** field as shown above (or use the `MODEL_NAME` environment variable), and your workers will automatically use the cached model for inference.
 
-To use cached models with [custom workers](/serverless/workers/custom-worker), you'll need to manually locate the cached model path and integrate it into your worker code.
+To use cached models with [custom workers](/serverless/quickstart), you'll need to manually locate the cached model path and integrate it into your worker code.
 
 ### Where cached models are stored
 

--- a/serverless/load-balancing/build-a-worker.mdx
+++ b/serverless/load-balancing/build-a-worker.mdx
@@ -131,7 +131,7 @@ docker push YOUR_DOCKER_USERNAME/loadbalancer-example:v1.0
 
 Now, let's deploy our application to a Serverless endpoint:
 
-1. Go to the [Serverless page](https://www.runpod.io/console/serverless) in the Runpod console.
+1. Go to the [Serverless page](https://console.runpod.io/serverless) in the Runpod console.
 2. Click **New Endpoint**
 3. Click **Import from Docker Registry**.
 4. In the **Container Image** field, enter your Docker image URL: 

--- a/serverless/load-balancing/vllm-worker.mdx
+++ b/serverless/load-balancing/vllm-worker.mdx
@@ -522,7 +522,7 @@ docker push YOUR_DOCKER_USERNAME/vllm-loadbalancer:v1.0
 
 Now, let's deploy our application to a Serverless endpoint:
 
-1. Go to the [Serverless page](https://www.runpod.io/console/serverless) in the Runpod console.
+1. Go to the [Serverless page](https://console.runpod.io/serverless) in the Runpod console.
 2. Click **New Endpoint**
 3. Click **Import from Docker Registry**.
 4. In the **Container Image** field, enter your Docker image URL:

--- a/serverless/overview.mdx
+++ b/serverless/overview.mdx
@@ -13,7 +13,7 @@ Runpod Serverless is a cloud computing platform that lets you serve AI models fo
 ## Get started
 
 <CardGroup cols={3}>
-    <Card title="Quickstart" href="/serverless/workers/custom-worker" icon="bolt" horizontal>
+    <Card title="Quickstart" href="/serverless/quickstart" icon="bolt" horizontal>
         Write a handler function, build a worker image, create an endpoint, and send your first request.
     </Card>
     <Card title="Generate images with ComfyUI" href="/tutorials/serverless/comfyui" icon="image" horizontal>

--- a/serverless/quickstart.mdx
+++ b/serverless/quickstart.mdx
@@ -12,7 +12,7 @@ For an even faster start, clone or download the [worker-basic](https://github.co
 
 ## Requirements
 
-* You've [created a Runpod account](/get-started/manage-accounts).
+* You've [created a Runpod account](/accounts-billing/manage-accounts).
 * You've installed [Python 3.10 or higher](https://www.python.org/downloads/) and [Docker](https://docs.docker.com/get-started/get-docker/) on your local machine and configured them for your command line.
 
 ## Step 1: Create project files

--- a/serverless/vllm/get-started.mdx
+++ b/serverless/vllm/get-started.mdx
@@ -6,7 +6,7 @@ description: "Create a Serverless endpoint to serve LLM inference via API reques
 
 ## Requirements
 
-* [Runpod account](/get-started/manage-accounts).
+* [Runpod account](/accounts-billing/manage-accounts).
 * [Runpod API key](/get-started/api-keys).
 * (For gated models) [Hugging Face access token](https://huggingface.co/docs/hub/en/security-tokens).
 
@@ -152,4 +152,4 @@ If you encounter issues with your deployment:
 * [Send requests using the Runpod API](/serverless/vllm/vllm-requests).
 * [Learn about vLLM's OpenAI API compatibility](/serverless/vllm/openai-compatibility).
 * [Customize your vLLM worker's handler function](/serverless/workers/handler-functions).
-* [Build a custom worker for more specialized workloads](/serverless/workers/custom-worker).
+* [Build a custom worker for more specialized workloads](/serverless/quickstart).

--- a/serverless/workers/concurrent-handler.mdx
+++ b/serverless/workers/concurrent-handler.mdx
@@ -5,7 +5,7 @@ description: "Build a concurrent handler function to process multiple requests s
 
 ## Requirements
 
-* You've [created a Runpod account](/get-started/manage-accounts).
+* You've [created a Runpod account](/accounts-billing/manage-accounts).
 * You've installed the Runpod SDK (`pip install runpod`).
 * You know how to build a [basic handler function](/serverless/workers/handler-functions).
 

--- a/tutorials/flash/build-rest-api-with-load-balancer.mdx
+++ b/tutorials/flash/build-rest-api-with-load-balancer.mdx
@@ -9,7 +9,7 @@ This tutorial shows you how to build a REST API using Flash load-balanced endpoi
 
 ## Requirements
 
-- You've [created a Runpod account](/get-started/manage-accounts)
+- You've [created a Runpod account](/accounts-billing/manage-accounts)
 - You've [created a Runpod API key](/get-started/api-keys)
 - You've installed [Python 3.10, 3.11, 3.12, or 3.13](https://www.python.org/downloads/).
 - You've completed the [Flash quickstart](/flash/quickstart) or are familiar with Flash basics
@@ -79,7 +79,7 @@ api = Endpoint(
 This configuration creates a CPU load-balanced endpoint that can handle multiple HTTP routes.
 
 <Note>
-**Worker Quota Considerations**: The `workers` setting determines the maximum number of concurrent workers. Standard Runpod accounts have a total quota of 30 workers across all endpoints. If you have other endpoints running, you may need to reduce `workers` to `(0, 1)`. Check your quota in the [Runpod console](https://www.runpod.io/console/serverless).
+**Worker Quota Considerations**: The `workers` setting determines the maximum number of concurrent workers. Standard Runpod accounts have a total quota of 30 workers across all endpoints. If you have other endpoints running, you may need to reduce `workers` to `(0, 1)`. Check your quota in the [Runpod console](https://console.runpod.io/serverless).
 </Note>
 
 ## Step 4: Add API routes
@@ -183,7 +183,7 @@ The sentiment analysis route uses a separate GPU endpoint because it requires di
 - Dependency installation (transformers, torch)
 - Model downloads (distilbert is ~250MB)
 
-During high demand periods, GPU provisioning may take longer. Check [GPU availability](https://www.runpod.io/console/serverless) in the console.
+During high demand periods, GPU provisioning may take longer. Check [GPU availability](https://console.runpod.io/serverless) in the console.
 </Note>
 
 ## Step 6: Add the main execution block
@@ -570,7 +570,7 @@ flowchart TB
 **Issue**: `Max workers across all endpoints must not exceed your workers quota (30)`
 
 **Solution**:
-1. Check your current worker usage in the [Runpod console](https://www.runpod.io/console/serverless)
+1. Check your current worker usage in the [Runpod console](https://console.runpod.io/serverless)
 2. Reduce `workers` in your configuration:
    ```python
    api = Endpoint(
@@ -632,7 +632,7 @@ pip install transformers torch
 **Issue**: GPU sentiment route stays in `IN_QUEUE` status
 
 **Solutions**:
-1. Check [GPU availability](https://www.runpod.io/console/serverless) in console
+1. Check [GPU availability](https://console.runpod.io/serverless) in console
 2. Use flexible GPU selection:
    ```python
    gpu=GpuGroup.ANY  # Use any available GPU
@@ -676,7 +676,7 @@ async def protected_route(text: str, api_key: str) -> dict:
 
 ### Monitor your API
 
-- Track endpoint health in the [Runpod console](https://www.runpod.io/console/serverless)
+- Track endpoint health in the [Runpod console](https://console.runpod.io/serverless)
 - Monitor request counts and error rates
 - Adjust `workers` based on traffic patterns
 

--- a/tutorials/flash/image-generation-with-sdxl.mdx
+++ b/tutorials/flash/image-generation-with-sdxl.mdx
@@ -13,7 +13,7 @@ This tutorial shows you how to build an image generation script using Flash and 
 
 ## Requirements
 
-- You've [created a Runpod account](/get-started/manage-accounts).
+- You've [created a Runpod account](/accounts-billing/manage-accounts).
 - You've [created a Runpod API key](/get-started/api-keys).
 - You've installed [Python 3.10, 3.11, 3.12, or 3.13](https://www.python.org/downloads/).
 - You've completed the [Flash quickstart](/flash/quickstart) or are familiar with Flash basics.
@@ -50,7 +50,7 @@ Create a `.env` file with your Runpod API key:
 touch .env && echo "RUNPOD_API_KEY=YOUR_API_KEY" > .env
 ```
 
-Replace `YOUR_API_KEY` with your actual API key from the [Runpod console](https://www.runpod.io/console/user/settings).
+Replace `YOUR_API_KEY` with your actual API key from the [Runpod console](https://console.runpod.io/user/settings).
 
 ## Step 2: Understand Stable Diffusion XL
 

--- a/tutorials/flash/text-generation-with-transformers.mdx
+++ b/tutorials/flash/text-generation-with-transformers.mdx
@@ -9,7 +9,7 @@ This tutorial shows you how to build a text generation script using Flash and Hu
 
 ## Requirements
 
-- You've [created a Runpod account](/get-started/manage-accounts).
+- You've [created a Runpod account](/accounts-billing/manage-accounts).
 - You've [created a Runpod API key](/get-started/api-keys).
 - You've installed [Python 3.10, 3.11, 3.12, or 3.13](https://www.python.org/downloads/).
 - You've completed the [Flash quickstart](/flash/quickstart) or are familiar with Flash basics.
@@ -46,7 +46,7 @@ Create a `.env` file with your Runpod API key:
 touch .env && echo "RUNPOD_API_KEY=YOUR_API_KEY" > .env
 ```
 
-Replace `YOUR_API_KEY` with your actual API key from the [Runpod console](https://www.runpod.io/console/user/settings).
+Replace `YOUR_API_KEY` with your actual API key from the [Runpod console](https://console.runpod.io/user/settings).
 
 ## Step 2: Understand the Hugging Face transformers library
 

--- a/tutorials/migrations/cog/overview.mdx
+++ b/tutorials/migrations/cog/overview.mdx
@@ -8,8 +8,8 @@ import { ServerlessTooltip, EndpointTooltip, WorkerTooltip, HandlerFunctionToolt
 
 To get started with Runpod:
 
-* [Create a Runpod account](/get-started/manage-accounts)
-* [Add funds](/references/billing-information)
+* [Create a Runpod account](/accounts-billing/manage-accounts)
+* [Add funds](/accounts-billing/billing)
 * [Use the Runpod SDK](/serverless/overview) to build and connect with your <ServerlessTooltip /> <EndpointTooltip />s
 
 In this tutorial, you'll go through the process of migrating a model deployed via replicate.com or utilizing the Cog framework to a Runpod Serverless <WorkerTooltip />.

--- a/tutorials/migrations/openai/overview.mdx
+++ b/tutorials/migrations/openai/overview.mdx
@@ -8,8 +8,8 @@ import { ServerlessTooltip, EndpointTooltip, WorkerTooltip, VLLMTooltip } from "
 
 To get started with Runpod:
 
-* [Create a Runpod account](/get-started/manage-accounts)
-* [Add funds](/references/billing-information)
+* [Create a Runpod account](/accounts-billing/manage-accounts)
+* [Add funds](/accounts-billing/billing)
 * [Use the Runpod SDK](/serverless/overview) to build and connect with your <ServerlessTooltip /> <EndpointTooltip />s
 
 This tutorial guides you through the steps necessary to modify your OpenAI Codebase for use with a deployed <VLLMTooltip /> <WorkerTooltip /> on Runpod. You will learn to adjust your code to be compatible with OpenAI's API, specifically for utilizing Chat Completions, Completions, and Models routes. By the end of this guide, you will have successfully updated your codebase, enabling you to leverage the capabilities of OpenAI's API on Runpod.

--- a/tutorials/pods/comfyui.mdx
+++ b/tutorials/pods/comfyui.mdx
@@ -22,7 +22,7 @@ For example, if you load a workflow created for the Flux Dev model and try to us
 
 Before you begin, you'll need:
 
-- A [Runpod account](/get-started/manage-accounts).
+- A [Runpod account](/accounts-billing/manage-accounts).
 - At least $10 in Runpod credits.
 - A basic understanding of AI image generation.
 
@@ -96,7 +96,7 @@ Once your Pod has finished initializing, you can open the ComfyUI interface:
 
 <Steps>
   <Step title="Open your Pod in the console">
-    Go to the [Pods section](https://www.runpod.io/console/pods) in the Runpod console, then find your deployed ComfyUI Pod and expand it.
+    Go to the [Pods section](https://console.runpod.io/pods) in the Runpod console, then find your deployed ComfyUI Pod and expand it.
 
     <Warning>
     The Pod may take up to 30 minutes to initialize when first deployed. Future starts will generally take much less time.

--- a/tutorials/pods/run-ollama.mdx
+++ b/tutorials/pods/run-ollama.mdx
@@ -85,5 +85,5 @@ For more API options, see the [Ollama API documentation](https://github.com/olla
 ## Next steps
 
 - Learn about [exposing ports](/pods/configuration/expose-ports) on Pods.
-- Connect [VSCode to Runpod](https://blog.runpod.io/how-to-connect-vscode-to-runpod/) for remote development.
+- Connect [VSCode to Runpod](https://www.runpod.io/articles/guides) for remote development.
 - Explore more models in the [Ollama library](https://ollama.com/library).

--- a/tutorials/pods/run-your-first.mdx
+++ b/tutorials/pods/run-your-first.mdx
@@ -15,7 +15,7 @@ The 3B parameter model we'll use in this tutorial requires only 24 GB of VRAM, m
 
 Before you begin, you'll need:
 
-- A [Runpod account](/get-started/manage-accounts).
+- A [Runpod account](/accounts-billing/manage-accounts).
 - At least $5 in Runpod credits.
 - Basic familiarity with Python and Jupyter notebooks.
 

--- a/tutorials/pods/use-private-ecr-images.mdx
+++ b/tutorials/pods/use-private-ecr-images.mdx
@@ -158,7 +158,7 @@ Replace `YOUR_REPOSITORY_NAME` with the name of your ECR repository.
 
 ## Step 3: Add your ECR credential to Runpod
 
-1. Navigate to [Settings](https://www.runpod.io/console/user/settings) in the Runpod console.
+1. Navigate to [Settings](https://console.runpod.io/user/settings) in the Runpod console.
 2. Scroll down to **Container Registry Authentication** and click **Add Credential**.
 3. Select **AWS ECR** as the registry type.
 4. Enter a **Name** for this credential (for example, `my-ecr-repo`).
@@ -175,7 +175,7 @@ You can deploy using a template or directly from the <PodTooltip /> deploy page.
 
 ### Option A: Deploy directly
 
-1. Navigate to [Pods](https://www.runpod.io/console/pods) and select **Deploy**.
+1. Navigate to [Pods](https://console.runpod.io/pods) and select **Deploy**.
 2. Choose your GPU configuration.
 3. Under **Container Image**, enter your full ECR image URI (for example, `123456789012.dkr.ecr.us-east-2.amazonaws.com/my-app:latest`).
 4. Configure any additional settings such as environment variables or exposed ports.
@@ -183,7 +183,7 @@ You can deploy using a template or directly from the <PodTooltip /> deploy page.
 
 ### Option B: Deploy via a template
 
-1. Navigate to [Templates](https://www.runpod.io/console/user/templates).
+1. Navigate to [Templates](https://console.runpod.io/user/templates).
 2. Create a new template or update an existing one.
 3. Set the **Container Image** to your ECR image URI.
 4. Save the template, then deploy a <PodTooltip /> from it.

--- a/tutorials/public-endpoints/text-to-video-pipeline.mdx
+++ b/tutorials/public-endpoints/text-to-video-pipeline.mdx
@@ -46,7 +46,7 @@ flowchart TD
 
 Before you begin, you'll need:
 
-- A [Runpod account](/get-started/manage-accounts) with at least \$1 in credits.
+- A [Runpod account](/accounts-billing/manage-accounts) with at least \$1 in credits.
 - A [Runpod API key](/get-started/api-keys).
 - Python 3.8 or later installed on your local machine.
 

--- a/tutorials/serverless/generate-sdxl-turbo.mdx
+++ b/tutorials/serverless/generate-sdxl-turbo.mdx
@@ -12,7 +12,7 @@ By the end, you'll know how to deploy <ServerlessTooltip /> endpoints from the H
 
 ## Requirements
 
-- A [Runpod account](/get-started/manage-accounts) with credits.
+- A [Runpod account](/accounts-billing/manage-accounts) with credits.
 - A [Runpod API key](/get-started/api-keys).
 
 ## Step 1: Deploy an endpoint from the Hub
@@ -43,7 +43,7 @@ Now that your endpoint is deployed, you'll need your endpoint ID and API key to 
 
 ### Find your API key
 
-1. Navigate to **Settings** > **API Keys** in the console, or go directly to the [API Keys page](https://www.runpod.io/console/user/settings).
+1. Navigate to **Settings** > **API Keys** in the console, or go directly to the [API Keys page](https://console.runpod.io/user/settings).
 2. Copy an existing API key, or create a new one with read and write permissions.
 
 <Tip>
@@ -309,6 +309,6 @@ The first request may take longer (30-60 seconds) due to <ColdStartTooltip /> as
 Now that you've integrated a Serverless endpoint into a web application, you can:
 
 - [Explore other workers on the Hub](/hub/overview) for different AI capabilities.
-- [Learn about asynchronous requests](/serverless/endpoints/operations) for handling long-running jobs.
+- [Learn about asynchronous requests](/serverless/endpoints/send-requests) for handling long-running jobs.
 - [Build your own custom worker](/serverless/workers/overview) to deploy your own models.
-- [Use the Python SDK](/sdks/python/endpoints) for more advanced integrations.
+- [Use the Python SDK](/serverless/endpoints/send-requests) for more advanced integrations.

--- a/tutorials/serverless/model-caching-text.mdx
+++ b/tutorials/serverless/model-caching-text.mdx
@@ -16,7 +16,7 @@ This tutorial demonstrates how to build a custom <ServerlessTooltip /> <WorkerTo
 
 Before starting this tutorial, make sure:
 
-- You have a [Runpod account](/get-started/manage-accounts) with sufficient credits.
+- You have a [Runpod account](/accounts-billing/manage-accounts) with sufficient credits.
 - You have a [Runpod API key](/get-started/api-keys).
 - You have a [GitHub account](https://github.com/). 
 - Your Runpod account is [connected to GitHub](/serverless/workers/github-integration#authorize-runpod-with-github).

--- a/tutorials/serverless/run-gemma-7b.mdx
+++ b/tutorials/serverless/run-gemma-7b.mdx
@@ -14,7 +14,7 @@ By the end, you'll have a fully functional Serverless endpoint that can respond 
 
 Before starting this tutorial, you'll need:
 
-- A [Runpod account](https://www.runpod.io/console/signup) with available credits.
+- A [Runpod account](https://console.runpod.io/signup) with available credits.
 - A [Runpod API key](/get-started/api-keys).
 - A [Hugging Face account](https://huggingface.co/join) and [access token](https://huggingface.co/settings/tokens).
 - Python 3.8+ installed on your local machine.

--- a/tutorials/serverless/run-your-first.mdx
+++ b/tutorials/serverless/run-your-first.mdx
@@ -204,7 +204,7 @@ Congratulations! You've successfully used Runpod's Serverless platform to genera
 
 Now that you've learned how to generate images with Serverless, consider exploring these advanced topics:
 
-- Learn how to create [synchronous requests](/serverless/endpoints/operations) using the `/runsync` endpoint for faster responses.
+- Learn how to create [synchronous requests](/serverless/endpoints/send-requests) using the `/runsync` endpoint for faster responses.
 - Explore [endpoint configurations](/serverless/endpoints/endpoint-configurations) to optimize performance and cost.
 - Discover how to [send requests](/serverless/endpoints/send-requests) with advanced parameters and webhook notifications.
 - Try deploying your own [custom worker](/serverless/quickstart) for specialized AI models.


### PR DESCRIPTION
## Summary

- point the shared docs logo directly to `/overview`
- replace legacy internal docs paths with their final 200 destinations
- replace old `www.runpod.io/console/*` links with direct `console.runpod.io` URLs
- update old Runpod blog, pricing, legal, and Help Center links found in the July 17 Ahrefs crawl

## Validation

- `node scripts/validate-tooltips.js` passed
- `git diff --check` passed
- `docs.json` parsed successfully
- all 23 targeted legacy patterns now have zero matches in MDX
- 24 of 25 final destinations returned HTTP 200; `contact.runpod.io` returned 403 to curl because of bot protection, but the destination is the Ahrefs-recorded final URL
- `npx -y mintlify@latest broken-links --check-redirects` reported only four pre-existing missing `.claude/*.md` references from `CLAUDE.md`; no changed content files were reported

No production deploy is included.