### PR TITLE
Fix Runpod casing in public docs

### DIFF
--- a/flash/quickstart.mdx
+++ b/flash/quickstart.mdx
@@ -122,7 +122,7 @@ Running matrix multiplication on Runpod GPU...
 Creating endpoint: flash-quickstart
 Provisioning Serverless endpoint...
 Endpoint ready
-Executing function on RunPod endpoint ID: xvf32dan8rcilp
+Executing function on Runpod endpoint ID: xvf32dan8rcilp
 Initial job status: IN_QUEUE
 Job completed, output received
 

--- a/flash/troubleshooting.mdx
+++ b/flash/troubleshooting.mdx
@@ -73,7 +73,7 @@ async def process(data: dict) -> dict:
 
 **Error:**
 ```
-No RunPod API key found. Set one with:
+No Runpod API key found. Set one with:
 
   flash login                              # interactive setup
                  or

--- a/public-endpoints/ai-coding-tools.mdx
+++ b/public-endpoints/ai-coding-tools.mdx
@@ -50,7 +50,7 @@ OpenCode supports multiple provider configurations, so you can set up both Runpo
     "provider": {
       "runpod-gpt": {
         "npm": "@ai-sdk/openai-compatible",
-        "name": "RunPod GPT OSS 120B",
+        "name": "Runpod GPT OSS 120B",
         "options": {
           "baseURL": "https://api.runpod.ai/v2/gpt-oss-120b/openai/v1",
           "apiKey": "{env:RUNPOD_API_KEY}"
@@ -58,14 +58,14 @@ OpenCode supports multiple provider configurations, so you can set up both Runpo
         "models": {
           "gpt-oss-120b": {
             "id": "openai/gpt-oss-120b",
-            "name": "GPT OSS 120B (RunPod)",
+            "name": "GPT OSS 120B (Runpod)",
             "limit": { "context": 131072, "output": 4096 }
           }
         }
       },
       "runpod-qwen": {
         "npm": "@ai-sdk/openai-compatible",
-        "name": "RunPod Qwen3",
+        "name": "Runpod Qwen3",
         "options": {
           "baseURL": "https://api.runpod.ai/v2/qwen3-32b-awq/openai/v1",
           "apiKey": "{env:RUNPOD_API_KEY}"
@@ -73,7 +73,7 @@ OpenCode supports multiple provider configurations, so you can set up both Runpo
         "models": {
           "qwen3-32b": {
             "id": "Qwen/Qwen3-32B-AWQ",
-            "name": "Qwen3 32B AWQ (RunPod)",
+            "name": "Qwen3 32B AWQ (Runpod)",
             "limit": { "context": 32768, "output": 4096 }
           }
         }

--- a/tutorials/flash/image-generation-with-sdxl.mdx
+++ b/tutorials/flash/image-generation-with-sdxl.mdx
@@ -310,7 +310,7 @@ This may take 1-2 minutes on first run (downloading model)...
 Creating endpoint: server_Endpoint_a1b2c3d4
 Provisioning Serverless endpoint...
 Endpoint ready
-Executing function on RunPod endpoint ID: xvf32dan8rcilp
+Executing function on Runpod endpoint ID: xvf32dan8rcilp
 Initial job status: IN_QUEUE
 Downloading model weights from Hugging Face...
 Model loaded, generating image...
@@ -335,7 +335,7 @@ Device: cuda
 Generating image with Stable Diffusion XL on Runpod GPU...
 
 Resource Endpoint_a1b2c3d4 already exists, reusing.
-Executing function on RunPod endpoint ID: xvf32dan8rcilp
+Executing function on Runpod endpoint ID: xvf32dan8rcilp
 Initial job status: IN_QUEUE
 Job completed, output received
 ✓ Image saved to generated_images/sdxl_output.png

--- a/tutorials/flash/text-generation-with-transformers.mdx
+++ b/tutorials/flash/text-generation-with-transformers.mdx
@@ -250,8 +250,8 @@ Starting text generation on Runpod GPU...
 Creating endpoint: server_Endpoint_a1b2c3d4
 Provisioning Serverless endpoint...
 Endpoint ready
-Registering RunPod endpoint at https://api.runpod.ai/xvf32dan8rcilp
-Executing function on RunPod endpoint ID: xvf32dan8rcilp
+Registering Runpod endpoint at https://api.runpod.ai/xvf32dan8rcilp
+Executing function on Runpod endpoint ID: xvf32dan8rcilp
 Initial job status: IN_QUEUE
 Installing dependencies: transformers torch accelerate
 Downloading model weights...
@@ -279,8 +279,8 @@ Max length: 100 tokens
 ```text
 Starting text generation on Runpod GPU...
 Resource Endpoint_a1b2c3d4 already exists, reusing.
-Registering RunPod endpoint at https://api.runpod.ai/xvf32dan8rcilp
-Executing function on RunPod endpoint ID: xvf32dan8rcilp
+Registering Runpod endpoint at https://api.runpod.ai/xvf32dan8rcilp
+Executing function on Runpod endpoint ID: xvf32dan8rcilp
 Initial job status: IN_QUEUE
 Job completed, output received
 


### PR DESCRIPTION
## What changed

Updated twelve public Docs references from `RunPod` to `Runpod` across Flash tutorials, troubleshooting output, quickstart output, and AI coding tool examples.

## Why

These examples and rendered snippets used the previous brand casing.

## Impact

Affected Docs pages will consistently display `Runpod` after review and release.

## Validation

- Repository scan confirms zero remaining `RunPod` matches
- Mintlify broken-link check found only four pre-existing links in `CLAUDE.md`, outside this diff
- `git diff --check` passed
- Production was not deployed