### PR TITLE
Fix remaining docs SEO outcome gaps

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -106,7 +106,7 @@
           "pods"
         ],
         "summary": "Create a new Pod",
-        "description": "Creates a new [Pod](#/components/schemas/Pod) and optionally deploys it. Review parameters and responses for this Runpod API operation.",
+        "description": "Creates a new [Pod](#/components/schemas/Pod) and optionally deploys it. Review parameters and responses for this Runpod API operation in detail.",
         "operationId": "CreatePod",
         "requestBody": {
           "description": "Input for Pod creation.",

--- a/docs.json
+++ b/docs.json
@@ -1349,6 +1349,10 @@
       "destination": "/serverless/endpoints/endpoint-configurations"
     },
     {
+      "source": "/docs/autoscaling",
+      "destination": "/serverless/endpoints/endpoint-configurations"
+    },
+    {
       "source": "/docs/serverless-ai",
       "destination": "/serverless/overview"
     },


### PR DESCRIPTION
## Summary

- Add a redirect from `/docs/autoscaling` to the current Serverless endpoint configuration page.
- Expand the Create Pod API description so the served text clears the short-description threshold after Markdown rendering.

## Why

The latest Ahrefs crawl found one remaining unintended docs 404 at `/docs/autoscaling`. The Create Pod operation description also measured 107 characters in rendered HTML because Markdown link syntax was counted in source but removed from the served metadata.

## Impact

The legacy autoscaling URL now resolves to current guidance. The Create Pod meta description renders at 117 characters, within the 110 to 160 character target.

## Validation

- `jq empty docs.json api-reference/openapi.json`
- No duplicate redirect sources
- Redirect destination maps to a tracked MDX page
- Rendered Create Pod description is 117 characters
- `node scripts/validate-tooltips.js`
- `git diff --check`
- Mintlify link check has the same four pre-existing `CLAUDE.md` references to absent `.claude` files on this branch and `origin/main`
