### PR TITLE
Fix Ahrefs redirecting documentation links

### DIFF
--- a/accounts-billing/billing.mdx
+++ b/accounts-billing/billing.mdx
@@ -69,7 +69,7 @@ Runpod accepts several payment methods:
 
 | Method | Details |
 |--------|---------|
-| Credit card | Visa, Mastercard, American Express, and other cards [supported by Stripe](https://stripe.com/docs/payments/cards/supported-card-brands). Prepaid cards should deposit at least \$100 per transaction. |
+| Credit card | Visa, Mastercard, American Express, and other cards [supported by Stripe](https://docs.stripe.com/payments/cards). Prepaid cards should deposit at least \$100 per transaction. |
 | Cryptocurrency | Accepted via integrated payment processors. Complete any required KYC verification before your first crypto payment. |
 | Business invoicing | Available for transactions over \$5,000. Supports ACH, wire transfer, and credit card. [Contact our sales team](https://ecykq.share.hsforms.com/2MZdZATC3Rb62Dgci7knjbA) to set up invoicing. |
 
@@ -125,7 +125,7 @@ For detailed cost attribution by team or project, see [Cost centers](/accounts-b
 
 Runpod credits are non-refundable and cannot be withdrawn once deposited. Credits can only be used for Runpod services.
 
-If you're new to Runpod and want to evaluate the platform, you can start with as little as \$10. Visit the [Discord community](https://discord.gg/pJ3P2DbUUq) to ask questions before committing to a larger deposit.
+If you're new to Runpod and want to evaluate the platform, you can start with as little as \$10. Visit the [Discord community](https://discord.com/invite/pJ3P2DbUUq) to ask questions before committing to a larger deposit.
 
 ## Billing support
 

--- a/accounts-billing/manage-payment-cards.mdx
+++ b/accounts-billing/manage-payment-cards.mdx
@@ -49,7 +49,7 @@ If your card continues to decline, consider these alternatives:
 - **Cryptocurrency**: Runpod accepts crypto payments through integrated processors.
 - **Business invoicing**: For deposits over \$5,000, [contact sales](https://ecykq.share.hsforms.com/2MZdZATC3Rb62Dgci7knjbA) to arrange invoicing via ACH or wire transfer.
 
-For supported card brands, see [Stripe's documentation](https://stripe.com/docs/payments/cards/supported-card-brands).
+For supported card brands, see [Stripe's documentation](https://docs.stripe.com/payments/cards).
 
 ### Step 4: Contact Runpod support
 

--- a/community-solutions/copyparty-file-manager/overview.mdx
+++ b/community-solutions/copyparty-file-manager/overview.mdx
@@ -12,7 +12,7 @@ CopyParty provides a webbased GUI that makes file management simple on Runpod in
 
 CopyParty is an open-source project created that provides a portable file server with a web UI. It's perfect for managing files on cloud GPU instances where traditional file transfer methods might be cumbersome.
 
-For a video demonstration, you can watch the [creator's YouTube tutorial](https://youtu.be/15_-hgsX2V0?si=AXArKvI79LEscpNn).
+For a video demonstration, you can watch the [creator's YouTube tutorial](https://www.youtube.com/watch?v=15_-hgsX2V0).
 
 <Note>
 Check the repository for additional features, updates, and documentation: [github.com/9001/copyparty](https://github.com/9001/copyparty)
@@ -86,7 +86,7 @@ apt-get update && apt-get install tmux -y && tmux new-session -d -s copyparty 'c
 
 `tmux` (terminal multiplexer) is a tool that lets you run terminal sessions in the background. Think of it as a way to keep programs running even after you close your terminal window, like minimizing an app instead of closing it. This is particularly useful on Runpod where you want CopyParty to keep running even if you disconnect.
 
-For a more in-depth tmux tutorial, check out this [comprehensive video guide](https://youtu.be/nTqu6w2wc68?si=OcI3qbh2kGH7_3fh).
+For a more in-depth tmux tutorial, check out this [comprehensive video guide](https://www.youtube.com/watch?v=nTqu6w2wc68).
 </Info>
 
 This command:

--- a/community-solutions/ohmyrunpod/overview.mdx
+++ b/community-solutions/ohmyrunpod/overview.mdx
@@ -147,7 +147,7 @@ Once SFTP is configured, you can:
 
 ## More community solutions
 
-Have a tool that solves common Runpod problems? Community contributions are welcome! Share your solutions in the [Runpod Discord](https://discord.gg/runpod) community.
+Have a tool that solves common Runpod problems? Community contributions are welcome! Share your solutions in the [Runpod Discord](https://discord.com/invite/runpod) community.
 
 ## Related Runpod documentation
 

--- a/community-solutions/overview.mdx
+++ b/community-solutions/overview.mdx
@@ -54,4 +54,4 @@ Browse through our community tools section in the sidebar for detailed documenta
 
 ## Contributing
 
-Built something useful on Runpod? The community would love to learn about it! Share your tools and get feedback in the [Runpod Discord](https://discord.gg/runpod).
+Built something useful on Runpod? The community would love to learn about it! Share your tools and get feedback in the [Runpod Discord](https://discord.com/invite/runpod).

--- a/docs.json
+++ b/docs.json
@@ -699,7 +699,7 @@
   },
   "footer": {
     "socials": {
-      "discord": "https://discord.gg/cUpRmau42V",
+      "discord": "https://discord.com/invite/cUpRmau42V",
       "x": "https://twitter.com/runpod_io",
       "instagram": "https://www.instagram.com/runpod.io"
     }

--- a/fine-tune.mdx
+++ b/fine-tune.mdx
@@ -7,9 +7,9 @@ import { InferenceTooltip } from "/snippets/tooltips.jsx";
 
 Fine-tuning is the process of taking a pre-trained large language model (LLM) and further training it on a smaller, specific dataset. This process adapts the model to a particular task or domain, improving its performance and accuracy for your use case.
 
-This guide explains how to use Runpod's fine-tuning feature, powered by [Axolotl](https://github.com/OpenAccess-AI-Collective/axolotl), to customize an LLM. You'll learn how to select a base model, choose a dataset, configure your training environment, and deploy your fine-tuned model.
+This guide explains how to use Runpod's fine-tuning feature, powered by [Axolotl](https://github.com/axolotl-ai-cloud/axolotl), to customize an LLM. You'll learn how to select a base model, choose a dataset, configure your training environment, and deploy your fine-tuned model.
 
-For more information about fine-tuning with Axolotl, see the [Axolotl Documentation](https://github.com/OpenAccess-AI-Collective/axolotl).
+For more information about fine-tuning with Axolotl, see the [Axolotl Documentation](https://github.com/axolotl-ai-cloud/axolotl).
 
 ## Requirements
 

--- a/flash/troubleshooting.mdx
+++ b/flash/troubleshooting.mdx
@@ -571,6 +571,6 @@ async def process(data: dict) -> dict:
 
 If you're still stuck:
 
-1. **Discord**: Join the [Runpod Discord](https://discord.gg/cUpRmau42V) for community support.
+1. **Discord**: Join the [Runpod Discord](https://discord.com/invite/cUpRmau42V) for community support.
 2. **GitHub Issues**: Report bugs or request features on the [Flash repository](https://github.com/runpod/flash).
 3. **Support**: Contact [Runpod support](https://www.runpod.io/contact) for account-specific issues.

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -360,6 +360,6 @@ runpodctl pod delete $RUNPOD_POD_ID
 
 ## Need help?
 
-* Join the Runpod community [on Discord](https://discord.gg/cUpRmau42V).
+* Join the Runpod community [on Discord](https://discord.com/invite/cUpRmau42V).
 * Submit a support request using our [contact page](https://contact.runpod.io/hc/requests/new).
 * Reach out to us via [email](mailto:help@runpod.io).

--- a/get-started/agent-skills.mdx
+++ b/get-started/agent-skills.mdx
@@ -7,7 +7,7 @@ tag: "NEW"
 
 The Runpod skills plugin teaches your coding agent how to run GPU workloads on Runpod. Once installed, you can ask your agent to create Pods, deploy Serverless endpoints, transfer files, or deploy your own code with Flash, all in natural language. A built-in router sends each request to the right skill, so you don't need to know which tool applies.
 
-It works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Cursor](https://www.cursor.com/), [GitHub Copilot](https://github.com/features/copilot), [Windsurf](https://codeium.com/windsurf), [Cline](https://github.com/cline/cline), and [many other AI agents](https://skills.sh/).
+It works with [Claude Code](https://code.claude.com/docs), [Codex](https://github.com/openai/codex), [Cursor](https://cursor.com/), [GitHub Copilot](https://github.com/features/copilot), [Windsurf](https://codeium.com/windsurf), [Cline](https://github.com/cline/cline), and [many other AI agents](https://www.skills.sh/).
 
 ## Quick start
 
@@ -160,7 +160,7 @@ If a command reports a name mismatch, list what's installed first with `/plugin 
   <Card title="Runpod skills repository" href="https://github.com/runpod/runpod-plugins-official" icon="github" horizontal>
     Source code and full skill definitions.
   </Card>
-  <Card title="skills.sh" href="https://skills.sh/" icon="wand-magic-sparkles" horizontal>
+  <Card title="skills.sh" href="https://www.skills.sh/" icon="wand-magic-sparkles" horizontal>
     The skills platform with the full list of compatible AI agents.
   </Card>
   <Card title="Runpod CLI reference" href="/runpodctl/overview" icon="terminal" horizontal>

--- a/get-started/mcp-servers.mdx
+++ b/get-started/mcp-servers.mdx
@@ -5,7 +5,7 @@ description: "Connect AI tools to Runpod using the Model Context Protocol for in
 tag: "NEW"
 ---
 
-Runpod provides two [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers that connect AI tools and coding agents directly to Runpod:
+Runpod provides two [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) servers that connect AI tools and coding agents directly to Runpod:
 
 - **[Runpod API MCP server](#runpod-api-mcp-server):** Manage Pods, endpoints, templates, volumes, and registries through the Runpod REST API. Requires a [Runpod API key](/get-started/api-keys).
 - **[Runpod docs MCP server](#runpod-docs-mcp-server):** Search Runpod documentation for features, code examples, and guides. No authentication required.

--- a/instant-clusters/axolotl.mdx
+++ b/instant-clusters/axolotl.mdx
@@ -109,4 +109,4 @@ Now that you've successfully deployed and tested an Axolotl distributed training
 * **Scale your training** by adjusting the number of Pods in your cluster (and the size of their containers and volumes) to handle larger models or datasets.
 * **Try different optimization techniques** such as DeepSpeed, FSDP (Fully Sharded Data Parallel), or other distributed training strategies.
 
-For more information on fine-tuning with Axolotl, refer to the [Axolotl documentation](https://github.com/OpenAccess-AI-Collective/axolotl).
+For more information on fine-tuning with Axolotl, refer to the [Axolotl documentation](https://github.com/axolotl-ai-cloud/axolotl).

--- a/integrations/dstack.mdx
+++ b/integrations/dstack.mdx
@@ -23,7 +23,7 @@ These instructions work on macOS, Linux, and Windows.
 
 **Windows users**
 
-Use [WSL (Windows Subsystem for Linux)](https://docs.microsoft.com/en-us/windows/wsl/install) or [Git Bash](https://gitforwindows.org/) to follow along with the Unix-like commands in this guide. Alternatively, use PowerShell or Command Prompt and adjust commands as needed.
+Use [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) or [Git Bash](https://gitforwindows.org/) to follow along with the Unix-like commands in this guide. Alternatively, use PowerShell or Command Prompt and adjust commands as needed.
 
 </Info>
 

--- a/integrations/transformer-lab.mdx
+++ b/integrations/transformer-lab.mdx
@@ -21,7 +21,7 @@ You'll need:
 
 **Windows users**
 
-Transformer Lab requires [WSL2 (Windows Subsystem for Linux)](https://docs.microsoft.com/en-us/windows/wsl/install). Install WSL2 first, then follow the Linux instructions within your WSL2 environment.
+Transformer Lab requires [WSL2 (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install). Install WSL2 first, then follow the Linux instructions within your WSL2 environment.
 
 </Note>
 
@@ -110,7 +110,7 @@ Refer to the [Transformer Lab documentation](https://lab.cloud/for-teams/advance
 
 Transformer Lab uses task files to define cloud workloads. Tasks specify the resources, setup commands, and run commands for your job.
 
-For detailed information on task configuration, see the [Task YAML Structure](https://lab.cloud/for-teams/running-a-task/task-yaml-structure) documentation. You can also browse the [Task Gallery](https://lab.cloud/for-teams/running-a-task/quick-start#4-import-a-task-from-tasks-gallery) for pre-built templates.
+For detailed information on task configuration, see the [Task YAML Structure](https://lab.cloud/for-teams/running-a-task/task-yaml-structure/) documentation. You can also browse the [Task Gallery](https://lab.cloud/for-teams/running-a-task/quick-start/#4-import-a-task-from-tasks-gallery) for pre-built templates.
 
 ### Create a task
 

--- a/overview.mdx
+++ b/overview.mdx
@@ -128,7 +128,7 @@ Create a multi-node [Instant Cluster](/instant-clusters) for fully managed distr
     <Card title="Status page" href="https://uptime.runpod.io/" icon="chart-line" horizontal>
         Check the status of Runpod services and infrastructure.
     </Card>
-    <Card title="Discord" href="https://discord.gg/cUpRmau42V" icon="discord" horizontal>
+    <Card title="Discord" href="https://discord.com/invite/cUpRmau42V" icon="discord" horizontal>
         Join the Runpod community on Discord.
     </Card>
 </CardGroup>

--- a/pods/configuration/connect-to-ide.mdx
+++ b/pods/configuration/connect-to-ide.mdx
@@ -12,7 +12,7 @@ Before you begin, you'll need:
 
 - A local development environment with VSCode or Cursor installed.
   - [Download VSCode](https://code.visualstudio.com/download).
-  - [Download Cursor](https://cursor.sh/).
+  - [Download Cursor](https://cursor.com/).
 - Familiarity with basic command-line operations and SSH.
 
 ## Step 1: Install the Remote-SSH extension

--- a/pods/storage/cloud-sync.mdx
+++ b/pods/storage/cloud-sync.mdx
@@ -78,7 +78,7 @@ Follow the steps below to sync your data with Google Cloud Storage:
   <Step title="Set up a service account">
    Create a service account specifically for Runpod access. This provides better security than using your primary account credentials.
 
-   Follow [Google's guide on creating service account keys](https://cloud.google.com/iam/docs/keys-create-delete) to generate a JSON key file. This key contains all necessary authentication information.
+   Follow [Google's guide on creating service account keys](https://docs.cloud.google.com/iam/docs/keys-create-delete) to generate a JSON key file. This key contains all necessary authentication information.
   </Step>
 
   <Step title="Sync your data with Runpod">

--- a/pods/templates/overview.mdx
+++ b/pods/templates/overview.mdx
@@ -30,11 +30,11 @@ import { PodTooltip } from "/snippets/tooltips.jsx";
 | Type | Description | Support |
 |------|-------------|---------|
 | **Official** | Curated by Runpod with proven demand and maintained quality. Regularly tested and updated. | Full Runpod support |
-| **Community** | Created by users and promoted based on community usage. Wide variety of specialized configurations. | [Community Discord](https://discord.gg/runpod) only |
+| **Community** | Created by users and promoted based on community usage. Wide variety of specialized configurations. | [Community Discord](https://discord.com/invite/runpod) only |
 | **Custom** | Created by you for specialized workloads. Can be private or shared publicly. | Self-supported |
 
 <Warning>
-Runpod does not maintain or provide customer support for community templates. If you encounter issues, contact the template creator directly or seek help on the [community Discord](https://discord.gg/runpod).
+Runpod does not maintain or provide customer support for community templates. If you encounter issues, contact the template creator directly or seek help on the [community Discord](https://discord.com/invite/runpod).
 </Warning>
 
 ## What templates include

--- a/pods/troubleshooting/jupyterlab-blank-page.mdx
+++ b/pods/troubleshooting/jupyterlab-blank-page.mdx
@@ -65,10 +65,10 @@ Verify the following:
 - You're using a template that supports JupyterLab on the documented port (typically 8888).
 - Any required environment variables or startup commands for Jupyter are correctly set in your template configuration. If you're not sure, check the template documentation.
 
-If still stuck, share your Pod logs and template configuration with support or in the [Runpod Discord](https://discord.gg/runpod).
+If still stuck, share your Pod logs and template configuration with support or in the [Runpod Discord](https://discord.com/invite/runpod).
 
 <Warning>
 
-Runpod does not maintain or provide customer support for community templates. If you encounter issues, contact the template creator directly or seek help on the [community Discord](https://discord.gg/runpod).
+Runpod does not maintain or provide customer support for community templates. If you encounter issues, contact the template creator directly or seek help on the [community Discord](https://discord.com/invite/runpod).
 
 </Warning>

--- a/pods/troubleshooting/pod-migration.mdx
+++ b/pods/troubleshooting/pod-migration.mdx
@@ -7,7 +7,7 @@ tag: "BETA"
 import { MachineTooltip } from "/snippets/tooltips.jsx";
 
 <Note>
-Pod migration is currently in beta. [Join our Discord](https://discord.gg/runpod) if you'd like to provide feedback.
+Pod migration is currently in beta. [Join our Discord](https://discord.com/invite/runpod) if you'd like to provide feedback.
 </Note>
 
 <iframe

--- a/public-endpoints/ai-coding-tools.mdx
+++ b/public-endpoints/ai-coding-tools.mdx
@@ -14,7 +14,7 @@ Before you start, you'll need:
 - A [Runpod account](/accounts-billing/manage-accounts) with an [API key](/get-started/api-keys), and at least \$5 in Runpod credits.
 - One or more of the following AI coding tools installed on your local machine:
   - [OpenCode](https://opencode.ai/): Terminal-based AI coding assistant.
-  - [Cursor](https://cursor.sh/): AI-powered code editor.
+  - [Cursor](https://cursor.com/): AI-powered code editor.
   - [Cline](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev): VS Code extension for AI-assisted coding.
 
 ## Available endpoints

--- a/references/billing-information.mdx
+++ b/references/billing-information.mdx
@@ -37,7 +37,7 @@ If your machine-based storage or network volume is terminated due to lack of fun
 
 Runpod does not offer the option to withdraw your unused balance after depositing funds. When you add funds to your Runpod account, credits are non-refundable and can only be used for Runpod services. Only deposit the amount you intend to use.
 
-If you aren't sure if Runpod is right for you, you can load as little as \$10 into your account to try things out. Visit the [Discord community](https://discord.gg/pJ3P2DbUUq) to ask questions or email [help@runpod.io](mailto:help@runpod.io). Refunds and trial credits are not currently offered due to processing overhead.
+If you aren't sure if Runpod is right for you, you can load as little as \$10 into your account to try things out. Visit the [Discord community](https://discord.com/invite/pJ3P2DbUUq) to ask questions or email [help@runpod.io](mailto:help@runpod.io). Refunds and trial credits are not currently offered due to processing overhead.
 
 If you have questions about billing or need assistance planning your Runpod expenses, contact support at [help@runpod.io](mailto:help@runpod.io).
 
@@ -49,7 +49,7 @@ Spending limits are implemented for newer accounts to prevent fraud. These limit
 
 Runpod accepts several payment methods for funding your account:
 
-1. **Credit Card**: You can use your credit card to fund your Runpod account. However, be aware that card declines are more common than you might think, and the reasons for them might not always be clear. If you're using a prepaid card, it's recommended to deposit in transactions of at least \$100 to avoid unexpected blocks due to Stripe's minimums for prepaid cards. For more information, review [cards accepted by Stripe](https://stripe.com/docs/payments/cards/supported-card-brands?ref=blog.runpod.io).
+1. **Credit Card**: You can use your credit card to fund your Runpod account. However, be aware that card declines are more common than you might think, and the reasons for them might not always be clear. If you're using a prepaid card, it's recommended to deposit in transactions of at least \$100 to avoid unexpected blocks due to Stripe's minimums for prepaid cards. For more information, review [cards accepted by Stripe](https://docs.stripe.com/payments/cards).
 
 2) **Crypto Payments**: Runpod also accepts crypto payments. It's recommended to set up a [crypto.com](https://crypto.com/?ref=blog.runpod.io) account and go through any KYC checks they may require ahead of time. This provides an alternate way of funding your account in case you run into issues with card payment.
 

--- a/serverless/vllm/configuration.mdx
+++ b/serverless/vllm/configuration.mdx
@@ -94,5 +94,5 @@ For production workloads, select multiple GPU types in your [endpoint configurat
 ## Additional resources
 
 - [vLLM recipes](https://docs.vllm.ai/projects/recipes/en/latest/index.html): Step-by-step deployment guides.
-- [Mistral + vLLM guide](https://docs.mistral.ai/deployment/self-deployment/vllm).
+- [Mistral + vLLM guide](https://docs.mistral.ai/models/deployment/local-deployment/vllm).
 - [Qwen + vLLM guide](https://qwen.readthedocs.io/en/latest/deployment/vllm.html).

--- a/serverless/vllm/openai-compatibility.mdx
+++ b/serverless/vllm/openai-compatibility.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "OpenAI compatibility"
 description: "Use OpenAI client libraries with your vLLM workers. Review setup, configuration, deployment, and operations guidance for Runpod Serverless."
 ---
 
-vLLM workers implement OpenAI API compatibility, so you can use [OpenAI client libraries](https://platform.openai.com/docs/libraries) with your deployed models.
+vLLM workers implement OpenAI API compatibility, so you can use [OpenAI client libraries](https://developers.openai.com/api/docs/libraries) with your deployed models.
 
 To integrate with OpenAI-compatible tools, just configure the base URL and API key using your Runpod API key and Serverless endpoint ID.
 

--- a/serverless/workers/github-integration.mdx
+++ b/serverless/workers/github-integration.mdx
@@ -195,7 +195,7 @@ You can enhance your workflow with GitHub Actions for testing before deployment:
 
    <Tip>
 
-   To add your Runpod API key to a GitHub secret, see [Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions).
+   To add your Runpod API key to a GitHub secret, see [Using secrets in GitHub Actions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets).
 
    </Tip>
 

--- a/storage/s3-api.mdx
+++ b/storage/s3-api.mdx
@@ -124,7 +124,7 @@ You can use the S3-compatible API to interact with your Runpod network volumes u
 
 *   [AWS s3 CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/index.html).
 *   [AWS s3api CLI](https://docs.aws.amazon.com/cli/latest/reference/s3api/).
-*   [The Boto3 Python library](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html).
+*   [The Boto3 Python library](https://docs.aws.amazon.com/boto3/latest/reference/services/s3.html).
 
 Standard AWS CLI operations such as `ls`, `cp`, `mv`, and `rm` work as expected for most file operations. The `sync` command works for basic use cases but may encounter issues with large numbers of files (10,000+) or complex directory structures.
 
@@ -611,4 +611,4 @@ For comprehensive documentation on AWS S3 commands and libraries, refer to:
 
 - [AWS CLI S3 reference](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/index.html).
 - [AWS S3 API reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html).
-- [Boto3 S3 reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html).
+- [Boto3 S3 reference](https://docs.aws.amazon.com/boto3/latest/reference/services/s3.html).

--- a/tips-and-tricks/tmux.mdx
+++ b/tips-and-tricks/tmux.mdx
@@ -16,7 +16,7 @@ To use TMUX, you need terminal access to your Runpod Pod (SSH, web terminal, or 
 
 ## Video tutorial
 
-For a comprehensive video guide on using TMUX, check out this excellent tutorial: [TMUX Tutorial on YouTube](https://youtu.be/nTqu6w2wc68?si=w0_TiikbaFVb-aCr)
+For a comprehensive video guide on using TMUX, check out this excellent tutorial: [TMUX Tutorial on YouTube](https://www.youtube.com/watch?v=nTqu6w2wc68)
 
 ## Installing TMUX
 

--- a/tutorials/introduction/containers/docker-commands.mdx
+++ b/tutorials/introduction/containers/docker-commands.mdx
@@ -459,7 +459,7 @@ This reference covers the most essential Docker commands. For comprehensive docu
 
 - [Docker CLI reference](https://docs.docker.com/reference/cli/docker/)
 - [Dockerfile reference](https://docs.docker.com/reference/dockerfile/)
-- [Docker Compose reference](https://docs.docker.com/compose/compose-file/)
+- [Docker Compose reference](https://docs.docker.com/reference/compose-file/)
 
 ## Next steps
 

--- a/tutorials/introduction/containers/persist-data.mdx
+++ b/tutorials/introduction/containers/persist-data.mdx
@@ -270,9 +270,9 @@ Be careful with `docker volume prune`—it removes all volumes not currently in 
 
 For deeper coverage of Docker storage concepts, see Docker's official documentation:
 
-- [Volumes documentation](https://docs.docker.com/storage/volumes/)
-- [Bind mounts](https://docs.docker.com/storage/bind-mounts/)
-- [Storage drivers](https://docs.docker.com/storage/storagedriver/)
+- [Volumes documentation](https://docs.docker.com/engine/storage/volumes/)
+- [Bind mounts](https://docs.docker.com/engine/storage/bind-mounts/)
+- [Storage drivers](https://docs.docker.com/engine/storage/drivers/)
 
 ## Next steps
 

--- a/tutorials/migrations/openai/overview.mdx
+++ b/tutorials/migrations/openai/overview.mdx
@@ -69,5 +69,5 @@ Congratulations! You've successfully modified your OpenAI codebase for use with 
 ## Next Steps
 
 * [Explore more tutorials on Runpod](/tutorials/introduction/overview)
-* [Learn more about OpenAI's API](https://platform.openai.com/docs/)
+* [Learn more about OpenAI's API](https://developers.openai.com/api/docs)
 * [Deploy your own <VLLMTooltip /> <WorkerTooltip /> on Runpod](https://www.console.runpod.io/serverless)

--- a/tutorials/pods/comfyui.mdx
+++ b/tutorials/pods/comfyui.mdx
@@ -8,7 +8,7 @@ import { TemplateTooltip, NetworkVolumeTooltip, RunpodCLITooltip, ServerlessTool
 
 This tutorial walks you through how to configure ComfyUI on a [GPU Pod](/pods/overview) and use it to generate images with text-to-image models.
 
-[ComfyUI](https://www.comfy.org/) is a node-based graphical interface for creating AI image generation workflows. Instead of writing code, you connect different components visually to build custom image generation pipelines. This approach provides flexibility to experiment with various models and techniques while maintaining an intuitive interface.
+[ComfyUI](https://comfy.org/) is a node-based graphical interface for creating AI image generation workflows. Instead of writing code, you connect different components visually to build custom image generation pipelines. This approach provides flexibility to experiment with various models and techniques while maintaining an intuitive interface.
 
 This tutorial uses the [SDXL-Turbo](https://huggingface.co/stabilityai/sdxl-turbo) model and a matching <TemplateTooltip />, but you can adapt these instructions for any model/template combination you want to use.
 

--- a/tutorials/pods/use-private-ecr-images.mdx
+++ b/tutorials/pods/use-private-ecr-images.mdx
@@ -7,7 +7,7 @@ hidden: true
 ---
 
 <Note>
-ECR image support is currently in beta. [Join our Discord](https://discord.gg/cUpRmau42V) to provide feedback and get support.
+ECR image support is currently in beta. [Join our Discord](https://discord.com/invite/cUpRmau42V) to provide feedback and get support.
 </Note>
 
 import { PodTooltip } from "/snippets/tooltips.jsx";

--- a/tutorials/serverless/comfyui.mdx
+++ b/tutorials/serverless/comfyui.mdx
@@ -6,7 +6,7 @@ description: "Learn how to deploy a Serverless endpoint running ComfyUI from the
 
 import { ServerlessTooltip, EndpointTooltip, WorkerTooltip, PodTooltip } from "/snippets/tooltips.jsx";
 
-In this tutorial, you will learn how to deploy a <ServerlessTooltip /> <EndpointTooltip /> running [ComfyUI](https://github.com/comfyanonymous/ComfyUI) on Runpod, submit image generation jobs using workflow JSON, monitor their progress, and decode the resulting images.
+In this tutorial, you will learn how to deploy a <ServerlessTooltip /> <EndpointTooltip /> running [ComfyUI](https://github.com/Comfy-Org/ComfyUI) on Runpod, submit image generation jobs using workflow JSON, monitor their progress, and decode the resulting images.
 
 [Runpod's Serverless platform](/serverless/overview) allows you to run AI/ML models in the cloud without managing infrastructure, automatically scaling resources as needed. ComfyUI is a powerful node-based interface for Stable Diffusion that provides fine-grained control over the image generation process through customizable workflows.
 
@@ -365,4 +365,3 @@ Now that you've learned how to generate images with ComfyUI on Serverless, you c
 
 - [runpod-workers/worker-comfyui](https://github.com/runpod-workers/worker-comfyui): Advanced configuration options for the ComfyUI Serverless worker.
 - [ComfyUI-to-API](/community-solutions/comfyui-to-api/overview): A community tool that analyzes your ComfyUI workflows and automatically generates a deployment-ready GitHub repository with Dockerfile and dependencies.
-


### PR DESCRIPTION
## Summary
- Replace the shared docs Discord URL with its direct 200 destination.
- Update source-controlled external links from the July 24 Ahrefs crawl to their verified final URLs.
- Preserve auth-required destinations and Mintlify-generated GitHub edit links.

## Why
Ahrefs flagged 301 docs pages because the shared footer Discord link redirects. Several additional source-controlled destinations have also moved.

## Impact
Documentation links resolve directly. Auth flows and Mintlify Suggest edits links remain unchanged.

## Validation
- docs.json parses successfully.
- node scripts/validate-tooltips.js passes with four pre-existing unused-import warnings.
- git diff --check passes.
- npx --yes mint@latest broken-links reports only four pre-existing relative links in CLAUDE.md.