### PR TITLE
Fix pricing typo on Moonshot Kimi page (%0.95 -> $0.95)

### DIFF
--- a/public-endpoints/models/moonshot-kimi.mdx
+++ b/public-endpoints/models/moonshot-kimi.mdx
@@ -13,7 +13,7 @@ Moonshot's Kimi family of models handles advanced reasoning and chat. It support
 | | |
 |---|---|
 | **Endpoint** | `https://api.runpod.ai/v2/moonshot-kimi/runsync` |
-| **Pricing** | \$4.00–\$15.00 per 1M output tokens, \%0.95-$3.00 per 1M input tokens |
+| **Pricing** | \$4.00–\$15.00 per 1M output tokens, \$0.95–\$3.00 per 1M input tokens |
 | **Type** | Text generation |
 
 <Note>


### PR DESCRIPTION
One-character fix on the Public Endpoints Moonshot Kimi page, line 16: the pricing summary reads `%0.95-$3.00 per 1M input tokens`. Corrected to `$0.95–$3.00` to match the dollar formatting used in the rest of the row.

Spotted while verifying today's input/output pricing split update (thank you for the fast turnaround on that). No other content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)