### PR TITLE
feat: Add more options to the "copy" context menu

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -29,10 +29,13 @@
   "contextual": {
     "options": [
       "copy",
+      "add-mcp",
+      "download-spec",
       "chatgpt",
       "claude",
       "cursor",
-      "vscode"
+      "vscode",
+      "aistudio"
     ]
   },
   "navigation": {


### PR DESCRIPTION
We want to add more options to the "copy" context menu as we currently only have these options:
<img width="317" height="306" alt="CleanShot 2026-07-28 at 10 27 57" src="https://github.com/user-attachments/assets/3c694190-261b-4caf-be98-4d508d141160" />

This PR adds the following:
- **add-mcp**: Copies the `npx add-mcp` command to install the MCP server
- **download-spect**: Downloads your deployment’s OpenAPI spec. If there are multiple specs, downloads them as a zip archive. Only appears on API reference pages.
- **aistudio**: Creates a Google AI Studio conversation with the current page as context (Similar to claude and chatgpt options)

Additional context & information about this can be found on mintlify's docs: https://www.mintlify.com/docs/ai/contextual-menu#menu-options