### PR TITLE
docs: prepare API v2 reference for future automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/api-reference-v2/ @lavanya-gunreddi

--- a/api-reference-v2/billing/get-aggregated-billing-history.mdx
+++ b/api-reference-v2/billing/get-aggregated-billing-history.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/billing
----

--- a/api-reference-v2/billing/get-instant-cluster-billing-history.mdx
+++ b/api-reference-v2/billing/get-instant-cluster-billing-history.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/billing/clusters
----

--- a/api-reference-v2/billing/get-network-volume-billing-history.mdx
+++ b/api-reference-v2/billing/get-network-volume-billing-history.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/billing/networkvolumes
----

--- a/api-reference-v2/billing/get-pod-billing-history.mdx
+++ b/api-reference-v2/billing/get-pod-billing-history.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/billing/pods
----

--- a/api-reference-v2/billing/get-public-endpoint-billing-history.mdx
+++ b/api-reference-v2/billing/get-public-endpoint-billing-history.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/billing/endpoints
----

--- a/api-reference-v2/billing/get-serverless-billing-history.mdx
+++ b/api-reference-v2/billing/get-serverless-billing-history.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/billing/serverless
----

--- a/api-reference-v2/catalog/get-a-cpu-type.mdx
+++ b/api-reference-v2/catalog/get-a-cpu-type.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/catalog/cpus/{id}
----

--- a/api-reference-v2/catalog/get-a-data-center.mdx
+++ b/api-reference-v2/catalog/get-a-data-center.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/catalog/datacenters/{id}
----

--- a/api-reference-v2/catalog/get-a-gpu-type.mdx
+++ b/api-reference-v2/catalog/get-a-gpu-type.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/catalog/gpus/{id}
----

--- a/api-reference-v2/catalog/list-cpu-types.mdx
+++ b/api-reference-v2/catalog/list-cpu-types.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/catalog/cpus
----

--- a/api-reference-v2/catalog/list-data-centers.mdx
+++ b/api-reference-v2/catalog/list-data-centers.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/catalog/datacenters
----

--- a/api-reference-v2/catalog/list-gpu-types.mdx
+++ b/api-reference-v2/catalog/list-gpu-types.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/catalog/gpus
----

--- a/api-reference-v2/network-volumes/create-a-network-volume.mdx
+++ b/api-reference-v2/network-volumes/create-a-network-volume.mdx
@@ -1,3 +1,0 @@
----
-openapi: post /v2/network-volumes
----

--- a/api-reference-v2/network-volumes/delete-a-network-volume.mdx
+++ b/api-reference-v2/network-volumes/delete-a-network-volume.mdx
@@ -1,3 +1,0 @@
----
-openapi: delete /v2/network-volumes/{id}
----

--- a/api-reference-v2/network-volumes/get-a-network-volume.mdx
+++ b/api-reference-v2/network-volumes/get-a-network-volume.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/network-volumes/{id}
----

--- a/api-reference-v2/network-volumes/list-network-volumes.mdx
+++ b/api-reference-v2/network-volumes/list-network-volumes.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/network-volumes
----

--- a/api-reference-v2/network-volumes/update-a-network-volume.mdx
+++ b/api-reference-v2/network-volumes/update-a-network-volume.mdx
@@ -1,3 +1,0 @@
----
-openapi: patch /v2/network-volumes/{id}
----

--- a/api-reference-v2/pods/create-a-pod.mdx
+++ b/api-reference-v2/pods/create-a-pod.mdx
@@ -1,3 +1,0 @@
----
-openapi: post /v2/pods
----

--- a/api-reference-v2/pods/get-a-pod.mdx
+++ b/api-reference-v2/pods/get-a-pod.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/pods/{id}
----

--- a/api-reference-v2/pods/list-pods.mdx
+++ b/api-reference-v2/pods/list-pods.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/pods
----

--- a/api-reference-v2/pods/stream-pod-logs.mdx
+++ b/api-reference-v2/pods/stream-pod-logs.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/pods/{id}/logs
----

--- a/api-reference-v2/pods/terminate-a-pod.mdx
+++ b/api-reference-v2/pods/terminate-a-pod.mdx
@@ -1,3 +1,0 @@
----
-openapi: delete /v2/pods/{id}
----

--- a/api-reference-v2/pods/trigger-a-pod-state-transition.mdx
+++ b/api-reference-v2/pods/trigger-a-pod-state-transition.mdx
@@ -1,3 +1,0 @@
----
-openapi: post /v2/pods/{id}/action
----

--- a/api-reference-v2/pods/update-a-pod.mdx
+++ b/api-reference-v2/pods/update-a-pod.mdx
@@ -1,3 +1,0 @@
----
-openapi: patch /v2/pods/{id}
----

--- a/api-reference-v2/registries/create-a-container-registry-credential.mdx
+++ b/api-reference-v2/registries/create-a-container-registry-credential.mdx
@@ -1,3 +1,0 @@
----
-openapi: post /v2/registries
----

--- a/api-reference-v2/registries/delete-a-container-registry-credential.mdx
+++ b/api-reference-v2/registries/delete-a-container-registry-credential.mdx
@@ -1,3 +1,0 @@
----
-openapi: delete /v2/registries/{id}
----

--- a/api-reference-v2/registries/get-a-container-registry-credential.mdx
+++ b/api-reference-v2/registries/get-a-container-registry-credential.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/registries/{id}
----

--- a/api-reference-v2/registries/list-container-registries.mdx
+++ b/api-reference-v2/registries/list-container-registries.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/registries
----

--- a/api-reference-v2/serverless/create-a-serverless-endpoint.mdx
+++ b/api-reference-v2/serverless/create-a-serverless-endpoint.mdx
@@ -1,3 +1,0 @@
----
-openapi: post /v2/serverless
----

--- a/api-reference-v2/serverless/delete-a-serverless-endpoint.mdx
+++ b/api-reference-v2/serverless/delete-a-serverless-endpoint.mdx
@@ -1,3 +1,0 @@
----
-openapi: delete /v2/serverless/{id}
----

--- a/api-reference-v2/serverless/get-a-serverless-endpoint.mdx
+++ b/api-reference-v2/serverless/get-a-serverless-endpoint.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/serverless/{id}
----

--- a/api-reference-v2/serverless/list-serverless-endpoint-releases.mdx
+++ b/api-reference-v2/serverless/list-serverless-endpoint-releases.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/serverless/{id}/releases
----

--- a/api-reference-v2/serverless/list-serverless-endpoint-workers.mdx
+++ b/api-reference-v2/serverless/list-serverless-endpoint-workers.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/serverless/{id}/workers
----

--- a/api-reference-v2/serverless/list-serverless-endpoints.mdx
+++ b/api-reference-v2/serverless/list-serverless-endpoints.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/serverless
----

--- a/api-reference-v2/serverless/stream-serverless-worker-logs.mdx
+++ b/api-reference-v2/serverless/stream-serverless-worker-logs.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/serverless/{id}/workers/{workerId}/logs
----

--- a/api-reference-v2/serverless/update-a-serverless-endpoint.mdx
+++ b/api-reference-v2/serverless/update-a-serverless-endpoint.mdx
@@ -1,3 +1,0 @@
----
-openapi: patch /v2/serverless/{id}
----

--- a/api-reference-v2/templates/create-a-template.mdx
+++ b/api-reference-v2/templates/create-a-template.mdx
@@ -1,3 +1,0 @@
----
-openapi: post /v2/templates
----

--- a/api-reference-v2/templates/delete-a-template.mdx
+++ b/api-reference-v2/templates/delete-a-template.mdx
@@ -1,3 +1,0 @@
----
-openapi: delete /v2/templates/{id}
----

--- a/api-reference-v2/templates/get-a-template.mdx
+++ b/api-reference-v2/templates/get-a-template.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/templates/{id}
----

--- a/api-reference-v2/templates/list-templates.mdx
+++ b/api-reference-v2/templates/list-templates.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /v2/templates
----

--- a/api-reference-v2/templates/update-a-template.mdx
+++ b/api-reference-v2/templates/update-a-template.mdx
@@ -1,3 +1,0 @@
----
-openapi: patch /v2/templates/{id}
----

--- a/docs.json
+++ b/docs.json
@@ -507,83 +507,11 @@
         "groups": [
           {
             "group": "API v2",
-            "pages": ["api-reference-v2/overview"]
-          },
-          {
-            "group": "Pods",
-            "pages": [
-              "api-reference-v2/pods/list-pods",
-              "api-reference-v2/pods/create-a-pod",
-              "api-reference-v2/pods/get-a-pod",
-              "api-reference-v2/pods/terminate-a-pod",
-              "api-reference-v2/pods/update-a-pod",
-              "api-reference-v2/pods/stream-pod-logs",
-              "api-reference-v2/pods/trigger-a-pod-state-transition"
-            ]
-          },
-          {
-            "group": "Serverless",
-            "pages": [
-              "api-reference-v2/serverless/list-serverless-endpoints",
-              "api-reference-v2/serverless/create-a-serverless-endpoint",
-              "api-reference-v2/serverless/get-a-serverless-endpoint",
-              "api-reference-v2/serverless/delete-a-serverless-endpoint",
-              "api-reference-v2/serverless/update-a-serverless-endpoint",
-              "api-reference-v2/serverless/list-serverless-endpoint-workers",
-              "api-reference-v2/serverless/list-serverless-endpoint-releases",
-              "api-reference-v2/serverless/stream-serverless-worker-logs"
-            ]
-          },
-          {
-            "group": "Templates",
-            "pages": [
-              "api-reference-v2/templates/list-templates",
-              "api-reference-v2/templates/create-a-template",
-              "api-reference-v2/templates/get-a-template",
-              "api-reference-v2/templates/delete-a-template",
-              "api-reference-v2/templates/update-a-template"
-            ]
-          },
-          {
-            "group": "Network Volumes",
-            "pages": [
-              "api-reference-v2/network-volumes/list-network-volumes",
-              "api-reference-v2/network-volumes/create-a-network-volume",
-              "api-reference-v2/network-volumes/get-a-network-volume",
-              "api-reference-v2/network-volumes/delete-a-network-volume",
-              "api-reference-v2/network-volumes/update-a-network-volume"
-            ]
-          },
-          {
-            "group": "Registries",
-            "pages": [
-              "api-reference-v2/registries/list-container-registries",
-              "api-reference-v2/registries/create-a-container-registry-credential",
-              "api-reference-v2/registries/get-a-container-registry-credential",
-              "api-reference-v2/registries/delete-a-container-registry-credential"
-            ]
-          },
-          {
-            "group": "Catalog",
-            "pages": [
-              "api-reference-v2/catalog/list-gpu-types",
-              "api-reference-v2/catalog/get-a-gpu-type",
-              "api-reference-v2/catalog/list-cpu-types",
-              "api-reference-v2/catalog/get-a-cpu-type",
-              "api-reference-v2/catalog/list-data-centers",
-              "api-reference-v2/catalog/get-a-data-center"
-            ]
-          },
-          {
-            "group": "Billing",
-            "pages": [
-              "api-reference-v2/billing/get-aggregated-billing-history",
-              "api-reference-v2/billing/get-pod-billing-history",
-              "api-reference-v2/billing/get-serverless-billing-history",
-              "api-reference-v2/billing/get-public-endpoint-billing-history",
-              "api-reference-v2/billing/get-network-volume-billing-history",
-              "api-reference-v2/billing/get-instant-cluster-billing-history"
-            ]
+            "pages": ["api-reference-v2/overview"],
+            "openapi": {
+              "source": "api-reference-v2/openapi.json",
+              "directory": "api-reference-v2"
+            }
           }
         ]
       },

--- a/docs.json
+++ b/docs.json
@@ -27,13 +27,7 @@
     }
   },
   "contextual": {
-    "options": [
-      "copy",
-      "chatgpt",
-      "claude",
-      "cursor",
-      "vscode"
-    ]
+    "options": ["copy", "chatgpt", "claude", "cursor", "vscode"]
   },
   "navigation": {
     "tabs": [
@@ -59,10 +53,7 @@
               "flash/overview",
               {
                 "group": "Quickstart",
-                "pages": [
-                  "flash/quickstart",
-                  "flash/windows-wsl2"
-                ]
+                "pages": ["flash/quickstart", "flash/windows-wsl2"]
               },
               "flash/pricing",
               "flash/create-endpoints",
@@ -335,9 +326,7 @@
         "groups": [
           {
             "group": "Introduction",
-            "pages": [
-              "tutorials/introduction/overview"
-            ]
+            "pages": ["tutorials/introduction/overview"]
           },
           {
             "group": "Serverless",
@@ -368,9 +357,7 @@
           },
           {
             "group": "Public Endpoints",
-            "pages": [
-              "tutorials/public-endpoints/text-to-video-pipeline"
-            ]
+            "pages": ["tutorials/public-endpoints/text-to-video-pipeline"]
           }
         ]
       },
@@ -379,9 +366,7 @@
         "groups": [
           {
             "group": "Community solutions",
-            "pages": [
-              "community-solutions/overview"
-            ]
+            "pages": ["community-solutions/overview"]
           },
           {
             "group": "Tools",
@@ -395,9 +380,7 @@
           },
           {
             "group": "Tips and tricks",
-            "pages": [
-              "tips-and-tricks/tmux"
-            ]
+            "pages": ["tips-and-tricks/tmux"]
           }
         ]
       },
@@ -449,9 +432,7 @@
         "groups": [
           {
             "group": "API v1",
-            "pages": [
-              "api-reference/overview"
-            ]
+            "pages": ["api-reference/overview"]
           },
           {
             "group": "Pods",
@@ -526,88 +507,86 @@
         "groups": [
           {
             "group": "API v2",
+            "pages": ["api-reference-v2/overview"]
+          },
+          {
+            "group": "Pods",
             "pages": [
-              "api-reference-v2/overview"
+              "api-reference-v2/pods/list-pods",
+              "api-reference-v2/pods/create-a-pod",
+              "api-reference-v2/pods/get-a-pod",
+              "api-reference-v2/pods/terminate-a-pod",
+              "api-reference-v2/pods/update-a-pod",
+              "api-reference-v2/pods/stream-pod-logs",
+              "api-reference-v2/pods/trigger-a-pod-state-transition"
             ]
-          },           
-        {
-          "group": "Pods",
-          "pages": [
-            "api-reference-v2/pods/list-pods",
-            "api-reference-v2/pods/create-a-pod",
-            "api-reference-v2/pods/get-a-pod",
-            "api-reference-v2/pods/terminate-a-pod",
-            "api-reference-v2/pods/update-a-pod", 
-            "api-reference-v2/pods/stream-pod-logs",
-            "api-reference-v2/pods/trigger-a-pod-state-transition"
-          ]
-        },
-        {
-          "group": "Serverless",
-          "pages": [
-            "api-reference-v2/serverless/list-serverless-endpoints",
-            "api-reference-v2/serverless/create-a-serverless-endpoint",
-            "api-reference-v2/serverless/get-a-serverless-endpoint",
-            "api-reference-v2/serverless/delete-a-serverless-endpoint",
-            "api-reference-v2/serverless/update-a-serverless-endpoint",
-            "api-reference-v2/serverless/list-serverless-endpoint-workers",
-            "api-reference-v2/serverless/list-serverless-endpoint-releases",
-            "api-reference-v2/serverless/stream-serverless-worker-logs"
-          ]
-        },
-        {
-          "group": "Templates",
-          "pages": [
-            "api-reference-v2/templates/list-templates",
-            "api-reference-v2/templates/create-a-template",
-            "api-reference-v2/templates/get-a-template",
-            "api-reference-v2/templates/delete-a-template",
-            "api-reference-v2/templates/update-a-template"
-          ]
-        },  
-        {
-          "group": "Network Volumes",
-          "pages": [
-            "api-reference-v2/network-volumes/list-network-volumes",
-            "api-reference-v2/network-volumes/create-a-network-volume",
-            "api-reference-v2/network-volumes/get-a-network-volume",
-            "api-reference-v2/network-volumes/delete-a-network-volume",
-            "api-reference-v2/network-volumes/update-a-network-volume"
-          ]
-        },
-        {
-          "group": "Registries",
-          "pages": [
-            "api-reference-v2/registries/list-container-registries",
-            "api-reference-v2/registries/create-a-container-registry-credential",
-            "api-reference-v2/registries/get-a-container-registry-credential",
-            "api-reference-v2/registries/delete-a-container-registry-credential"
-          ]
-        },
-        {
-          "group": "Catalog",
-          "pages": [
-            "api-reference-v2/catalog/list-gpu-types",
-            "api-reference-v2/catalog/get-a-gpu-type",
-            "api-reference-v2/catalog/list-cpu-types",
-            "api-reference-v2/catalog/get-a-cpu-type",
-            "api-reference-v2/catalog/list-data-centers",
-            "api-reference-v2/catalog/get-a-data-center"
-          ]
-        },
-        {
-          "group": "Billing",
-          "pages": [
-            "api-reference-v2/billing/get-aggregated-billing-history",
-            "api-reference-v2/billing/get-pod-billing-history",
-            "api-reference-v2/billing/get-serverless-billing-history",
-            "api-reference-v2/billing/get-public-endpoint-billing-history",
-            "api-reference-v2/billing/get-network-volume-billing-history",
-            "api-reference-v2/billing/get-instant-cluster-billing-history"
-          ]
-        }
+          },
+          {
+            "group": "Serverless",
+            "pages": [
+              "api-reference-v2/serverless/list-serverless-endpoints",
+              "api-reference-v2/serverless/create-a-serverless-endpoint",
+              "api-reference-v2/serverless/get-a-serverless-endpoint",
+              "api-reference-v2/serverless/delete-a-serverless-endpoint",
+              "api-reference-v2/serverless/update-a-serverless-endpoint",
+              "api-reference-v2/serverless/list-serverless-endpoint-workers",
+              "api-reference-v2/serverless/list-serverless-endpoint-releases",
+              "api-reference-v2/serverless/stream-serverless-worker-logs"
+            ]
+          },
+          {
+            "group": "Templates",
+            "pages": [
+              "api-reference-v2/templates/list-templates",
+              "api-reference-v2/templates/create-a-template",
+              "api-reference-v2/templates/get-a-template",
+              "api-reference-v2/templates/delete-a-template",
+              "api-reference-v2/templates/update-a-template"
+            ]
+          },
+          {
+            "group": "Network Volumes",
+            "pages": [
+              "api-reference-v2/network-volumes/list-network-volumes",
+              "api-reference-v2/network-volumes/create-a-network-volume",
+              "api-reference-v2/network-volumes/get-a-network-volume",
+              "api-reference-v2/network-volumes/delete-a-network-volume",
+              "api-reference-v2/network-volumes/update-a-network-volume"
+            ]
+          },
+          {
+            "group": "Registries",
+            "pages": [
+              "api-reference-v2/registries/list-container-registries",
+              "api-reference-v2/registries/create-a-container-registry-credential",
+              "api-reference-v2/registries/get-a-container-registry-credential",
+              "api-reference-v2/registries/delete-a-container-registry-credential"
+            ]
+          },
+          {
+            "group": "Catalog",
+            "pages": [
+              "api-reference-v2/catalog/list-gpu-types",
+              "api-reference-v2/catalog/get-a-gpu-type",
+              "api-reference-v2/catalog/list-cpu-types",
+              "api-reference-v2/catalog/get-a-cpu-type",
+              "api-reference-v2/catalog/list-data-centers",
+              "api-reference-v2/catalog/get-a-data-center"
+            ]
+          },
+          {
+            "group": "Billing",
+            "pages": [
+              "api-reference-v2/billing/get-aggregated-billing-history",
+              "api-reference-v2/billing/get-pod-billing-history",
+              "api-reference-v2/billing/get-serverless-billing-history",
+              "api-reference-v2/billing/get-public-endpoint-billing-history",
+              "api-reference-v2/billing/get-network-volume-billing-history",
+              "api-reference-v2/billing/get-instant-cluster-billing-history"
+            ]
+          }
         ]
-    },
+      },
       {
         "tab": "Models",
         "groups": [
@@ -673,9 +652,7 @@
       },
       {
         "tab": "Release notes",
-        "pages": [
-          "release-notes"
-        ]
+        "pages": ["release-notes"]
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Configure Mintlify to generate the API v2 reference navigation directly from `api-reference-v2/openapi.json`.
- Remove the redundant one-line endpoint MDX wrappers and their hand-maintained navigation entries.
- Route changes under `api-reference-v2/` to the docs code owner.

> [!IMPORTANT]
> This PR does **not** enable automatic docs updates. It is only the docs-repository precursor that prepares the API v2 reference for later automation from Frontdoor. The separate Frontdoor workflow, dedicated GitHub App configuration, and required credentials must land before automatic updates can run.

## Verification

- `node scripts/validate-tooltips.js`
- Validated `docs.json` parses and points the API v2 group at the existing `api-reference-v2/openapi.json` source and directory.
- `git diff --check origin/main...HEAD`
- Verified `.github/CODEOWNERS` contains `/api-reference-v2/ @lavanya-gunreddi` with a trailing newline.

