### PR TITLE
Fix legacy documentation 404s: 67 redirects plus 4 pre-existing defects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1597,6 +1597,266 @@
     {
       "source": "/tutorials/build-docker-images-with-bazel",
       "destination": "/tutorials/pods/build-docker-images"
+    },
+    {
+      "source": "/hosts/how-to-become-a-host",
+      "destination": "/overview"
+    },
+    {
+      "source": "/docs/invites",
+      "destination": "/accounts-billing/manage-accounts"
+    },
+    {
+      "source": "/docs/create-pod",
+      "destination": "/api-reference-v2/pods/create-a-pod"
+    },
+    {
+      "source": "/docs/partner-requirements",
+      "destination": "/references/security-and-compliance"
+    },
+    {
+      "source": "/docs/transfer-data",
+      "destination": "/pods/storage/transfer-files"
+    },
+    {
+      "source": "/docs/using-s3-to-upload-files-with-serverless",
+      "destination": "/serverless/endpoints/send-requests"
+    },
+    {
+      "source": "/docs/overview",
+      "destination": "/overview"
+    },
+    {
+      "source": "/docs/microsoft-azure-blob-storage",
+      "destination": "/pods/storage/cloud-sync"
+    },
+    {
+      "source": "/docs/dropbox",
+      "destination": "/pods/storage/cloud-sync"
+    },
+    {
+      "source": "/docs/download-a-folder-from-a-pod",
+      "destination": "/pods/storage/transfer-files"
+    },
+    {
+      "source": "/docs/create-pod-template",
+      "destination": "/api-reference-v2/templates/create-a-template"
+    },
+    {
+      "source": "/docs/stop-pod",
+      "destination": "/api-reference-v2/pods/terminate-a-pod"
+    },
+    {
+      "source": "/docs/amazon-s3",
+      "destination": "/pods/storage/cloud-sync"
+    },
+    {
+      "source": "/gpu-instances/pod-env-variables",
+      "destination": "/pods/templates/environment-variables"
+    },
+    {
+      "source": "/ai-endpoints/image-based/anything-v4-sd-v1.5",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/reference/status",
+      "destination": "/serverless/endpoints/operation-reference"
+    },
+    {
+      "source": "/docs/updating-your-endpoint",
+      "destination": "/serverless/endpoints/endpoint-configurations"
+    },
+    {
+      "source": "/reference/openjourney-sd-v15",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/ai-endpoints/image-based/openjourney-sd-v1.5",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/reference/health-check",
+      "destination": "/serverless/endpoints/operation-reference"
+    },
+    {
+      "source": "/docs/create-serverless-endpoint",
+      "destination": "/api-reference-v2/serverless/create-a-serverless-endpoint"
+    },
+    {
+      "source": "/serverless-gpus/custom-apis",
+      "destination": "/serverless/overview"
+    },
+    {
+      "source": "/changelog",
+      "destination": "/release-notes"
+    },
+    {
+      "source": "/welcome/how-do-i/use-real-ssh",
+      "destination": "/pods/configuration/use-ssh"
+    },
+    {
+      "source": "/flash/mothership",
+      "destination": "/flash/overview"
+    },
+    {
+      "source": "/docs/handler-generator",
+      "destination": "/serverless/workers/handler-functions"
+    },
+    {
+      "source": "/tutorials/serverless/gpu/run-gemma-7b",
+      "destination": "/tutorials/serverless/run-gemma-7b"
+    },
+    {
+      "source": "/tutorials/introduction/containers/overview",
+      "destination": "/tutorials/introduction/containers"
+    },
+    {
+      "source": "/category/troubleshooting",
+      "destination": "/serverless/troubleshooting"
+    },
+    {
+      "source": "/flash/cli/run",
+      "destination": "/flash/cli/overview"
+    },
+    {
+      "source": "/networkvolumes",
+      "destination": "/storage/network-volumes"
+    },
+    {
+      "source": "/serverless/endpoints/invoke-jobs",
+      "destination": "/serverless/endpoints/send-requests"
+    },
+    {
+      "source": "/references/manage-payment-cards",
+      "destination": "/accounts-billing/manage-payment-cards"
+    },
+    {
+      "source": "/introduction/containers/dockerfile",
+      "destination": "/tutorials/introduction/containers/create-dockerfiles"
+    },
+    {
+      "source": "/serverless-ai-api/dreambooth",
+      "destination": "/public-endpoints/overview"
+    },
+    {
+      "source": "/docs/expose-ports",
+      "destination": "/pods/configuration/expose-ports"
+    },
+    {
+      "source": "/billing/pods",
+      "destination": "/api-reference/billing/GET/billing/pods"
+    },
+    {
+      "source": "/docs/customize-a-template",
+      "destination": "/pods/templates/create-custom-template"
+    },
+    {
+      "source": "/docs/using-your-api-copy",
+      "destination": "/serverless/endpoints/send-requests"
+    },
+    {
+      "source": "/pods/cold-starts",
+      "destination": "/serverless/development/optimization"
+    },
+    {
+      "source": "/cli/templates",
+      "destination": "/runpodctl/reference/runpodctl-template"
+    },
+    {
+      "source": "/cli/install",
+      "destination": "/runpodctl/overview"
+    },
+    {
+      "source": "/graphql/manage-endpoints",
+      "destination": "/sdks/graphql/manage-endpoints"
+    },
+    {
+      "source": "/runpodctl/reference/runpodctl_start",
+      "destination": "/runpodctl/reference/runpodctl-pod"
+    },
+    {
+      "source": "/runpodctl/reference/runpodctl_stop_pod",
+      "destination": "/runpodctl/reference/runpodctl-pod"
+    },
+    {
+      "source": "/docs/local-testing",
+      "destination": "/serverless/development/local-testing"
+    },
+    {
+      "source": "/docs/use-real-ssh",
+      "destination": "/pods/configuration/use-ssh"
+    },
+    {
+      "source": "/serverless/endpoints/error-handling",
+      "destination": "/serverless/workers/handler-functions"
+    },
+    {
+      "source": "/serverless/workers/concurrent-handler.",
+      "destination": "/serverless/workers/concurrent-handler"
+    },
+    {
+      "source": "/docs/how-to-become-a-host",
+      "destination": "/overview"
+    },
+    {
+      "source": "/docs/transfer-files-with-rsync",
+      "destination": "/pods/storage/transfer-files"
+    },
+    {
+      "source": "/docs/get-pod",
+      "destination": "/api-reference-v2/pods/get-a-pod"
+    },
+    {
+      "source": "/api-reference/pods/GET/pods/POD_ID",
+      "destination": "/api-reference/pods/GET/pods/podId"
+    },
+    {
+      "source": "/docs/github-integration",
+      "destination": "/serverless/workers/github-integration"
+    },
+    {
+      "source": "/docs/serverless-overview",
+      "destination": "/serverless/overview"
+    },
+    {
+      "source": "/runpodctl/reference/runpodctl-remove",
+      "destination": "/runpodctl/reference/runpodctl-pod"
+    },
+    {
+      "source": "/serverless/quick-start",
+      "destination": "/serverless/quickstart"
+    },
+    {
+      "source": "/flash/managing-endpoints",
+      "destination": "/flash/create-endpoints"
+    },
+    {
+      "source": "/category/deploy",
+      "destination": "/serverless/workers/deploy"
+    },
+    {
+      "source": "/category/containers",
+      "destination": "/tutorials/introduction/containers"
+    },
+    {
+      "source": "/category/endpoints",
+      "destination": "/serverless/endpoints/overview"
+    },
+    {
+      "source": "/runpodctl/reference/runpodctl_send",
+      "destination": "/runpodctl/reference/runpodctl-send"
+    },
+    {
+      "source": "/runpodctl/reference/runpodctl_create_pod",
+      "destination": "/runpodctl/reference/runpodctl-pod"
+    },
+    {
+      "source": "/tutorials/serverless/gpu/run-your-first",
+      "destination": "/tutorials/serverless/run-your-first"
+    },
+    {
+      "source": "/tutorials/serverless/gpu/generate-sdxl-turbo",
+      "destination": "/tutorials/serverless/generate-sdxl-turbo"
     }
   ]
 }

--- a/docs.json
+++ b/docs.json
@@ -871,6 +871,14 @@
       "destination": "/serverless/endpoints/send-requests"
     },
     {
+      "source": "/tutorials/pods/run-fooocus",
+      "destination": "/tutorials/pods/comfyui"
+    },
+    {
+      "source": "/category/vllm-endpoints",
+      "destination": "/serverless/vllm/overview"
+    },
+    {
       "source": "/glossary",
       "destination": "/get-started/concepts"
     },

--- a/docs.json
+++ b/docs.json
@@ -815,8 +815,8 @@
       "destination": "/serverless/endpoints/send-requests"
     },
     {
-      "source": "pods/references/environment-variables",
-      "destination": "pods/templates/environment-variables"
+      "source": "/pods/references/environment-variables",
+      "destination": "/pods/templates/environment-variables"
     },
     {
       "source": "/runpodctl/projects/get-started",
@@ -868,11 +868,11 @@
     },
     {
       "source": "/serverless/endpoints/job-operations",
-      "destination": "/serverless/endpoints/operations"
+      "destination": "/serverless/endpoints/send-requests"
     },
     {
       "source": "/glossary",
-      "destination": "/references/glossary"
+      "destination": "/get-started/concepts"
     },
     {
       "source": "/get-started/billing-information",
@@ -1164,7 +1164,7 @@
     },
     {
       "source": "/endpoints/health",
-      "destination": "/serverless/endpoints/operations"
+      "destination": "/serverless/endpoints/send-requests"
     },
     {
       "source": "/serverless/autoscaling",


### PR DESCRIPTION
## Summary

Closes the legacy-URL 404 gap on docs.runpod.io. 67 new redirect entries, plus repairs to four pre-existing defects in the `redirects` array. Scoped entirely to `docs.json`.

Source of truth: the GSC "Not found (404)" export (1,000 of 1,095 rows; GSC caps the export).

## What the 1,095 actually is

The headline number is not 1,095 broken doc pages. Broken down:

| Bucket | Count | Action |
|---|---|---|
| Non-docs-host paths | 438 | Out of scope for this repo |
| Docs asset / code / example paths | 178 | Not pages, no redirect appropriate |
| Actual unique docs paths | 319 | In scope |
| ... already covered by existing redirects | 35 | No change |
| ... covered by this PR | 67 | Added here |
| ... deliberately left 404 | remainder | See below |

## Why this is not a wildcard

Mintlify supports `{ "source": "/docs/:slug*", "destination": "/:slug*" }`, and it is the obvious-looking fix. It does not work here and would make things worse.

The legacy structure used flat GitBook slugs (`/docs/create-pod`, `/docs/handler-async`); the current IA is nested (`/pods/manage-pods`, `/serverless/handlers/...`). Tested against the live sitemap, stripping the `/docs` prefix resolves **1 of 71** archived legacy paths. Shipping the wildcard would convert hard 404s into 308-redirects-to-404: it burns crawl budget, creates soft-404 signals, and hides the problem from the Page Indexing report without fixing it.

Same trap on the CLI block: dead paths use underscores (`/references/runpodctl/runpodctl_config`), live pages use hyphens (`/runpodctl/reference/runpodctl-config`). Every one of these migrations changed the slug shape, not just the prefix, so each needs an explicit entry.

## Two additions that carry real traffic

Both still 404'd after the main pass and both have twelve-month GSC demand:

| Path | Impressions | Clicks | Destination |
|---|---|---|---|
| `/tutorials/pods/run-fooocus` | 7,386 | 218 | `/tutorials/pods/comfyui` |
| `/category/vllm-endpoints` | 411 | 5 | `/serverless/vllm/overview` |

The Fooocus tutorial was removed with no direct replacement. ComfyUI is the closest surviving equivalent (same task, image-generation UI on a Pod). Flagging it as a judgment call, happy to change it.

## Pre-existing defects repaired (drive-by, separate commit)

All four were on `main` before this branch:

- `pods/references/environment-variables` had no leading slash on source or destination, producing a relative redirect target.
- Three 2-hop chains flattened to their final destination:
  - `/serverless/endpoints/job-operations` -> `/serverless/endpoints/send-requests`
  - `/endpoints/health` -> `/serverless/endpoints/send-requests`
  - `/glossary` -> `/get-started/concepts`

## Deliberately left as 404

Paths with no inbound links, no impressions, and no surviving equivalent. A 404 is the correct response for content that no longer exists, and Google drops these on its own. Mintlify cannot emit 410, so 404 is also the only option. Redirecting them to a section hub would manufacture soft 404s and make the property worse.

Example: `/pods/monitoring/prometheus` (one inbound link, zero impressions, no equivalent page).

The right success metric is zero dead paths *with external signal*, not zero 404s.

## Verification

- All 99 unique redirect destinations return HTTP 200 live. No exceptions.
- 0 duplicate sources.
- 0 redirect chains (a destination that is itself a source).
- 0 malformed entries (every source and destination is root-relative).
- `docs.json` parses as valid JSON; redirect count 223 -> 290.
- `node scripts/validate-tooltips.js` passes.

## Not addressed here, worth a separate conversation

The largest single traffic loss in the dead set is the `/hosting/*` cluster, deleted with no replacement: `/hosting/overview` (11,750 impressions), `/hosting/maintenance-and-reliability` (2,567), `/hosting/burn-testing` (820). Roughly 15,100 impressions a year of host and partner facing documentation with no equivalent anywhere in the current 304-page site. Those three currently redirect to `/references/security-and-compliance`, which is a holding pattern, not an answer. That is a content decision, not a redirect decision.