### PR TITLE
Update overview.mdx - no auth req

### DIFF
--- a/api-reference-v2/overview.mdx
+++ b/api-reference-v2/overview.mdx
@@ -40,15 +40,13 @@ Retrieve the complete OpenAPI specification for client generation, request valid
 ```bash cURL
 curl --request GET \
   --url https://api.runpod.io/v2/openapi.json \
-  --header 'Authorization: Bearer RUNPOD_API_KEY'
 ```
 
 ```python Python
 import requests
 
 url = "https://api.runpod.io/v2/openapi.json"
-headers = {"Authorization": "Bearer RUNPOD_API_KEY"}
-response = requests.get(url, headers=headers)
+response = requests.get(url)
 print(response.json())
 ```
 

--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -30,16 +30,14 @@ Retrieve the complete OpenAPI specification for client generation, request valid
 
 ```bash cURL
 curl --request GET \
-  --url https://rest.runpod.io/v1/openapi.json \
-  --header 'Authorization: Bearer RUNPOD_API_KEY'
+  --url https://rest.runpod.io/v1/openapi.json \  
 ```
 
 ```python Python
 import requests
 
 url = "https://rest.runpod.io/v1/openapi.json"
-headers = {"Authorization": "Bearer RUNPOD_API_KEY"}
-response = requests.get(url, headers=headers)
+response = requests.get(url)
 print(response.json())
 ```
 


### PR DESCRIPTION
The OpenAPI spec URL (api.runpod.io/v2/openapi.json) is actually public — no auth required. Same cchanges to be applied in v1 file as well. 