### PR TITLE
chore: comment out Runpod Assistant chat widget

### DIFF
--- a/chat-widget.js
+++ b/chat-widget.js
@@ -1,11 +1,12 @@
 // Runpod Docs Chat Widget
-const WIDGET_BASE_URL = "https://runpod-assistant-doc-backend.vercel.app";
-
-const script = document.createElement("script");
-script.src = `${WIDGET_BASE_URL}/chat-widget.js`;
-script.async = true;
-script.setAttribute("data-api-url", `${WIDGET_BASE_URL}/api`);
-script.setAttribute("data-title", "Runpod Assistant");
-script.setAttribute("data-greeting", "Hi! How can I help you with Runpod today?");
-script.setAttribute("data-primary-color", "#5D29F0");
-document.head.appendChild(script);
+// Temporarily disabled — uncomment to re-enable the Runpod Assistant widget.
+// const WIDGET_BASE_URL = "https://runpod-assistant-doc-backend.vercel.app";
+//
+// const script = document.createElement("script");
+// script.src = `${WIDGET_BASE_URL}/chat-widget.js`;
+// script.async = true;
+// script.setAttribute("data-api-url", `${WIDGET_BASE_URL}/api`);
+// script.setAttribute("data-title", "Runpod Assistant");
+// script.setAttribute("data-greeting", "Hi! How can I help you with Runpod today?");
+// script.setAttribute("data-primary-color", "#5D29F0");
+// document.head.appendChild(script);


### PR DESCRIPTION
## Summary

Comments out the Runpod Assistant chat widget injection in `chat-widget.js`. Mintlify still loads the file, but it no longer appends the widget script from `runpod-assistant-doc-backend`.

The code is left in place (commented) rather than deleted, so the widget can be re-enabled by uncommenting.

## Testing

- `chat-widget.js` is the only widget injection point in the repo (no references in `docs.json`, snippets, or MDX).