### PR TITLE
Fix external 404 links in Docker and Flash docs

### DIFF
--- a/flash/apps/deploy-apps.mdx
+++ b/flash/apps/deploy-apps.mdx
@@ -224,7 +224,7 @@ uv run flash deploy --exclude scipy,pandas
 
 <Tip>
 
-Check the [worker-flash repository](https://github.com/runpod-workers/worker-flash) for current base images and pre-installed packages.
+Check the [Flash repository](https://github.com/runpod/flash) for current base images and pre-installed packages.
 
 </Tip>
 

--- a/flash/cli/build.mdx
+++ b/flash/cli/build.mdx
@@ -144,7 +144,7 @@ flash build --exclude scipy,pandas
 
 <Tip>
 
-Check the [worker-flash repository](https://github.com/runpod-workers/worker-flash) for current base images and pre-installed packages.
+Check the [Flash repository](https://github.com/runpod/flash) for current base images and pre-installed packages.
 
 </Tip>
 

--- a/tutorials/introduction/containers.mdx
+++ b/tutorials/introduction/containers.mdx
@@ -109,7 +109,7 @@ This tutorial series guides you through container fundamentals in a hands-on way
 
 Ready to get hands-on with Docker? Start with [creating your first Dockerfile](/tutorials/introduction/containers/create-dockerfiles).
 
-For more in-depth container concepts, see Docker's [container concepts documentation](https://docs.docker.com/guides/docker-concepts/).
+For more in-depth container concepts, see Docker's [container concepts documentation](https://docs.docker.com/get-started/).
 
 When you're ready to deploy containers on Runpod:
 


### PR DESCRIPTION
## What changed

- Replaced Docker's retired container concepts URL with the current Get Started page.
- Replaced two references to the retired `runpod-workers/worker-flash` repository with `runpod/flash`.

## Why

Ahrefs Site Audit issue `c64daf06-d0f4-11e7-8ed1-001e67ed4656` reported these three source links as 404s in the 2026-08-05 crawl.

## Impact

Readers now land on current upstream documentation and the active Runpod Flash repository. No product behavior or navigation structure changes.

## Validation

- `node scripts/validate-tooltips.js` passed.
- `git show --check` passed.
- All three old URLs are absent and replacement URLs are present.
- Both replacement destinations return HTTP 200.
- Vale reported three pre-existing `5GB` unit-spacing errors outside the changed lines.