### PR TITLE
ci: add CODEOWNERS file for api-reference-v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/api-reference-v2/ @lavanya-gunreddi


### PR DESCRIPTION
This will enable @lavanya-gunreddi to be notified when the openapi spec for rest api v2 is updated.