### PR TITLE
Add redirects for new Ahrefs legacy docs 404s

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1867,6 +1867,18 @@
     {
       "source": "/tutorials/serverless/gpu/generate-sdxl-turbo",
       "destination": "/tutorials/serverless/generate-sdxl-turbo"
+    },
+    {
+      "source": "/serverless/serverless-vllm",
+      "destination": "/serverless/vllm/overview"
+    },
+    {
+      "source": "/storage/overview",
+      "destination": "/storage/network-volumes"
+    },
+    {
+      "source": "/pods/clusters/overview",
+      "destination": "/instant-clusters"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- redirect the retired Serverless vLLM route to the current vLLM overview
- redirect the retired storage overview to network volumes
- redirect the retired Pods clusters overview to Clusters docs

## Scope
These three source URLs are present in Ahrefs Site Audit project 3648513, crawl 2026-08-12T19:58:57Z, issue c64da643-d0f4-11e7-8ed1-001e67ed4656.

## Validation
- docs.json parses
- all 293 redirect sources are unique
- all three destination MDX files exist
- all three published destination URLs return HTTP 200
- node scripts/validate-tooltips.js
- git diff --check

Production remains review-bound. This PR was not merged.