### PR TITLE
robots.txt: stop Googlebot crawling versioned Mintlify asset chunks

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+Disallow: /cdn-cgi/
+Allow: /_next/image
+Allow: /mintlify-assets/_next/image
+Disallow: /_next/
+Disallow: /mintlify-assets/_next/
+Sitemap: https://docs.runpod.io/sitemap.xml


### PR DESCRIPTION
Follow-up to #738.

## Why

The GSC "Not found (404)" bucket on the domain property doubled from ~1.1K to
2.17K between 2026-07-19 and 07-30. The new entries are almost entirely
`/mintlify-assets/_next/static/chunks/*.js?dpl=...` URLs: deployment-versioned
JS chunks that 404 the moment the next Mintlify deploy replaces them. Google
keeps discovering fresh ones, so the report accumulates asset noise forever and
buries the real page 404s that #738's redirects fixed. A fresh validation was
started 2026-08-13; without this change it will keep failing on asset churn
alone.

## Why the default robots.txt does not already cover this

The live auto-generated robots.txt disallows `/_next/` but Mintlify serves the
same tree under the `/mintlify-assets/` prefix, and robots rules are pure
prefix matches, so `/mintlify-assets/_next/...` is crawlable today.

## What

Adds a repo-root `robots.txt` (Mintlify serves it as-is), reproducing the
current live default verbatim and adding the same pattern one directory deeper:

- `Allow: /mintlify-assets/_next/image` (mirrors the existing `/_next/image` allowance)
- `Disallow: /mintlify-assets/_next/`

No page content, sitemap, llms.txt, or AI-assistant access changes. The
existing `Content-Signal` line is preserved as-is.

## Effect

Googlebot stops crawling versioned chunks; the ~1K asset 404s age out of the
report on their own; the 404 report goes back to measuring real pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
