### PR TITLE
Fix remaining short meta descriptions

### DIFF
--- a/api-reference-v2/openapi.json
+++ b/api-reference-v2/openapi.json
@@ -4756,7 +4756,7 @@
       "get": {
         "operationId": "listPods",
         "summary": "List pods",
-        "description": "Returns pods owned by the authenticated user. Cluster member\npods are excluded by default; set `includeClusterPods=true` to include\nthem (each carries a non-null `cluster` membership block).\n",
+        "description": "Returns Pods owned by the authenticated user, with optional inclusion of Cluster member Pods and their Cluster membership details.\nCluster member Pods are excluded by default; set `includeClusterPods=true` to include\nthem (each carries a non-null `cluster` membership block).\n",
         "tags": [
           "Pods"
         ],
@@ -5056,7 +5056,7 @@
       "get": {
         "operationId": "getPod",
         "summary": "Get a pod",
-        "description": "Returns a single pod by ID.",
+        "description": "Returns a single Pod by ID, including its current status, compute configuration, storage, networking, and permitted actions.",
         "tags": [
           "Pods"
         ],
@@ -5533,7 +5533,7 @@
       "post": {
         "operationId": "podAction",
         "summary": "Trigger a pod state transition",
-        "description": "Triggers a state transition on a pod. Send a JSON body with a single\n`action` field, e.g. `{ \"action\": \"stop\" }`.\n\nValid actions:\n- `start`     — boot a stopped pod (`EXITED` or `ERROR`) back toward\n  `RUNNING`.\n- `stop`      — stop a running or provisioning pod, releasing GPU/CPU\n  compute while keeping its disk. The pod moves to `EXITED`.\n- `restart`   — restart a `RUNNING` pod's container in place.\n- `terminate` — permanently delete the pod and release its resources\n  (equivalent to `deletePod`).\n\nWhich actions are valid depends on the pod's current status, and the\ncurrently permitted set is published in the pod's `actions` field:\n`RUNNING` allows `stop`/`restart`/`terminate`; `EXITED` and `ERROR`\nallow `start`/`terminate`; `PROVISIONING` and `STARTING` allow\n`stop`/`terminate`.\n\n`start`, `stop`, and `restart` return `200` with the updated pod.\n`terminate` returns `204` with no body. Requesting an action that is\nnot valid for the pod's current status returns `409`.\n",
+        "description": "Triggers a state transition on a Pod by ID. Send a JSON body with one action: start, stop, restart, or terminate.\n\nValid actions:\n- `start`     — boot a stopped pod (`EXITED` or `ERROR`) back toward\n  `RUNNING`.\n- `stop`      — stop a running or provisioning pod, releasing GPU/CPU\n  compute while keeping its disk. The pod moves to `EXITED`.\n- `restart`   — restart a `RUNNING` pod's container in place.\n- `terminate` — permanently delete the pod and release its resources\n  (equivalent to `deletePod`).\n\nWhich actions are valid depends on the pod's current status, and the\ncurrently permitted set is published in the pod's `actions` field:\n`RUNNING` allows `stop`/`restart`/`terminate`; `EXITED` and `ERROR`\nallow `start`/`terminate`; `PROVISIONING` and `STARTING` allow\n`stop`/`terminate`.\n\n`start`, `stop`, and `restart` return `200` with the updated pod.\n`terminate` returns `204` with no body. Requesting an action that is\nnot valid for the pod's current status returns `409`.\n",
         "tags": [
           "Pods"
         ],
@@ -6046,7 +6046,7 @@
       "get": {
         "operationId": "listEndpoints",
         "summary": "List serverless endpoints",
-        "description": "Returns all serverless endpoints owned by the authenticated user.",
+        "description": "Returns all Serverless endpoints owned by the authenticated user, including configuration, scaling settings, and current worker state.",
         "tags": [
           "Serverless"
         ],
@@ -6332,7 +6332,7 @@
       "get": {
         "operationId": "getEndpoint",
         "summary": "Get a serverless endpoint",
-        "description": "Returns a single serverless endpoint by ID.",
+        "description": "Returns a single Serverless endpoint by ID, including its configuration, scaling settings, worker state, and deployment details.",
         "tags": [
           "Serverless"
         ],
@@ -6964,7 +6964,7 @@
       "get": {
         "operationId": "listTemplates",
         "summary": "List templates",
-        "description": "Returns all templates owned by the authenticated user.",
+        "description": "Returns all templates owned by the authenticated user so you can review reusable Pod and Serverless endpoint configurations.",
         "tags": [
           "Templates"
         ],
@@ -7194,7 +7194,7 @@
       "get": {
         "operationId": "getTemplate",
         "summary": "Get a template",
-        "description": "Returns the full configuration of a single template by ID. Serves\nboth templates you own and public catalog templates — everything you\ncan read. Updates and deletes remain restricted to templates you own.\n",
+        "description": "Returns the full configuration of a single template by ID, including templates you own and public catalog templates available to your account.\nUpdates and deletes remain restricted to templates you own.\n",
         "tags": [
           "Templates"
         ],
@@ -7467,7 +7467,7 @@
       "get": {
         "operationId": "listNetworkVolumes",
         "summary": "List network volumes",
-        "description": "Returns all network volumes owned by the authenticated user.",
+        "description": "Returns all network volumes owned by the authenticated user, including the configuration and current state of each volume.",
         "tags": [
           "Network Volumes"
         ],
@@ -7646,7 +7646,7 @@
       "get": {
         "operationId": "getNetworkVolume",
         "summary": "Get a network volume",
-        "description": "Returns a single network volume by ID.",
+        "description": "Returns a single network volume by ID, including its data center, storage size, current state, and associated resource details.",
         "tags": [
           "Network Volumes"
         ],
@@ -7825,7 +7825,7 @@
       "delete": {
         "operationId": "deleteNetworkVolume",
         "summary": "Delete a network volume",
-        "description": "Permanently deletes a network volume and releases its storage.",
+        "description": "Permanently deletes a network volume by ID and releases its storage after confirming the volume belongs to the authenticated user.",
         "tags": [
           "Network Volumes"
         ],
@@ -7878,7 +7878,7 @@
       "get": {
         "operationId": "listRegistries",
         "summary": "List container registries",
-        "description": "Returns all container registry credentials owned by the authenticated user.",
+        "description": "Returns all private container registry credentials owned by the authenticated user so you can inspect and manage connected registries.",
         "tags": [
           "Registries"
         ],
@@ -7946,7 +7946,7 @@
       "post": {
         "operationId": "createRegistry",
         "summary": "Create a container registry credential",
-        "description": "Stores credentials for a private container registry. Credentials are write-only.",
+        "description": "Stores credentials for a private container registry so Pods and Serverless workers can pull images without exposing credentials in requests.",
         "tags": [
           "Registries"
         ],

--- a/api-reference-v2/overview.mdx
+++ b/api-reference-v2/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "API v2"
 sidebarTitle: "Overview"
-description: "Programmatically manage Runpod resources using the API v2."
+description: "Use Runpod API v2 to programmatically manage Pods, Serverless endpoints, network volumes, templates, and container registries."
 ---
 
 <Warning>

--- a/instant-clusters/cluster-observability.mdx
+++ b/instant-clusters/cluster-observability.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cluster observability"
 sidebarTitle: "Cluster observability"
-description: "Monitor your training workloads in real time with built-in Grafana dashboards."
+description: "Monitor Runpod Clusters in real time with built-in Grafana dashboards for GPU, host, network, storage, and system health metrics."
 ---
 
 Instant Clusters include a built-in observability engine that streams cluster metrics at 5-second granularity directly to a Grafana dashboard. No configuration is required. Authentication is handled automatically when you launch a cluster.

--- a/serverless/endpoints/rolling-releases.mdx
+++ b/serverless/endpoints/rolling-releases.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Rolling releases"
 sidebarTitle: "Rolling releases"
-description: "How Runpod deploys endpoint updates without taking your endpoint offline."
+description: "Learn how Runpod uses rolling releases to replace Serverless workers progressively while endpoints continue accepting and processing requests."
 ---
 
 When you update an endpoint's Docker image or configuration, Runpod deploys the change as a rolling release. Workers are replaced progressively rather than all at once, so your endpoint continues to handle requests throughout the update.

--- a/tutorials/pods/use-private-ecr-images.mdx
+++ b/tutorials/pods/use-private-ecr-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Use private AWS ECR images"
 sidebarTitle: "Private ECR images"
-description: "Pull container images from private AWS ECR repositories using cross-account delegation."
+description: "Deploy Pods from private AWS ECR images by configuring cross-account IAM delegation, repository permissions, and Runpod credentials."
 tag: "BETA"
 ---
 


### PR DESCRIPTION
## Summary

- expands 16 descriptions from the current Ahrefs short-description report
- updates four page frontmatter descriptions and twelve API v2 operation summaries
- keeps each new search description between 100 and 155 characters

## Verification

- OpenAPI JSON parses successfully
- tooltip validation passes
- git diff --check passes

No production deployment is included.