### PR TITLE
chore: tune Mintlify configuration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5,7 +5,7 @@
   "colors": {
     "primary": "#5F4CFE",
     "light": "#9289FE",
-    "dark": "#9289FE"
+    "dark": "#5F4CFE"
   },
   "background": {},
   "styling": {
@@ -941,11 +941,11 @@
     },
     {
       "source": "/serverless/workers/handlers/handler-error-handling",
-      "destination": "/serverless/workers/handler-functions#error-handling"
+      "destination": "/serverless/workers/handler-functions"
     },
     {
       "source": "/serverless/development/error-handling",
-      "destination": "/serverless/workers/handler-functions#error-handling"
+      "destination": "/serverless/workers/handler-functions"
     },
     {
       "source": "/serverless/workers/handlers/overview",
@@ -1501,7 +1501,7 @@
     },
     {
       "source": "/gpu-memory-management",
-      "destination": "/serverless/troubleshooting#oom-errors"
+      "destination": "/serverless/troubleshooting"
     },
     {
       "source": "/graphql/overview",
@@ -1569,7 +1569,7 @@
     },
     {
       "source": "/secure-cloud",
-      "destination": "/pods/choose-a-pod#secure-cloud-vs-community-cloud"
+      "destination": "/pods/choose-a-pod"
     },
     {
       "source": "/serverless-ai/custom-apis/autoscaling",
@@ -1617,7 +1617,7 @@
     },
     {
       "source": "/serverless/workers/flashboot",
-      "destination": "/serverless/endpoints/endpoint-configurations#flashboot"
+      "destination": "/serverless/endpoints/endpoint-configurations"
     },
     {
       "source": "/serverless/workers/get-started",


### PR DESCRIPTION
## Summary
- remove unsupported fragments from five redirect destinations
- use the existing primary purple for the dark color role so Mintlify contrast checks pass

## Validation
- `npx --yes mint@latest validate`
- `python3 ~/.codex/skills/configure-mintlify/scripts/audit_mintlify_config.py .`
- `npx --yes mint@latest a11y --skip-alt-text`
- `node scripts/validate-tooltips.js`
- `git diff --check`

## Scope
- `docs.json` only
- draft PR, no merge or production deployment

## Baseline
- full broken-link check still reports 29 pre-existing issues in 20 files
- full accessibility check still reports 22 pre-existing missing-alt issues in 18 files