### PR TITLE
fix(runpodctl): correct the windows install command

### DIFF
--- a/runpodctl/overview.mdx
+++ b/runpodctl/overview.mdx
@@ -99,9 +99,32 @@ export PATH="$HOME/.local/bin:$PATH"
 </Tab>
 
 <Tab title="Windows">
-```bash
-wget https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.exe -O runpodctl.exe
+
+In PowerShell, `wget` is an alias for `Invoke-WebRequest`, so use `Invoke-WebRequest` directly. This installs runpodctl to `%LOCALAPPDATA%\runpodctl` and adds it to your `PATH`, so you can run `runpodctl` from any terminal.
+
+**AMD64 (x86_64):**
+```powershell
+$dest = "$env:LOCALAPPDATA\runpodctl"
+Invoke-WebRequest -UseBasicParsing -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.zip -OutFile "$env:TEMP\runpodctl.zip"
+Expand-Archive -Force -Path "$env:TEMP\runpodctl.zip" -DestinationPath $dest
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath -notlike "*$dest*") {
+  [Environment]::SetEnvironmentVariable('Path', "$userPath;$dest", 'User')
+}
 ```
+
+**ARM64:**
+```powershell
+$dest = "$env:LOCALAPPDATA\runpodctl"
+Invoke-WebRequest -UseBasicParsing -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-arm64.zip -OutFile "$env:TEMP\runpodctl.zip"
+Expand-Archive -Force -Path "$env:TEMP\runpodctl.zip" -DestinationPath $dest
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath -notlike "*$dest*") {
+  [Environment]::SetEnvironmentVariable('Path', "$userPath;$dest", 'User')
+}
+```
+
+Open a new terminal so the `PATH` change takes effect, then verify with `runpodctl version`.
 
 </Tab>
 

--- a/runpodctl/overview.mdx
+++ b/runpodctl/overview.mdx
@@ -108,8 +108,9 @@ $dest = "$env:LOCALAPPDATA\runpodctl"
 Invoke-WebRequest -UseBasicParsing -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.zip -OutFile "$env:TEMP\runpodctl.zip"
 Expand-Archive -Force -Path "$env:TEMP\runpodctl.zip" -DestinationPath $dest
 $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-if ($userPath -notlike "*$dest*") {
-  [Environment]::SetEnvironmentVariable('Path', "$userPath;$dest", 'User')
+$pathEntries = @($userPath -split ';' | Where-Object { $_ })
+if ($pathEntries -notcontains $dest) {
+  [Environment]::SetEnvironmentVariable('Path', (($pathEntries + $dest) -join ';'), 'User')
 }
 ```
 
@@ -119,8 +120,9 @@ $dest = "$env:LOCALAPPDATA\runpodctl"
 Invoke-WebRequest -UseBasicParsing -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-arm64.zip -OutFile "$env:TEMP\runpodctl.zip"
 Expand-Archive -Force -Path "$env:TEMP\runpodctl.zip" -DestinationPath $dest
 $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-if ($userPath -notlike "*$dest*") {
-  [Environment]::SetEnvironmentVariable('Path', "$userPath;$dest", 'User')
+$pathEntries = @($userPath -split ';' | Where-Object { $_ })
+if ($pathEntries -notcontains $dest) {
+  [Environment]::SetEnvironmentVariable('Path', (($pathEntries + $dest) -join ';'), 'User')
 }
 ```
 


### PR DESCRIPTION
The Windows install command on [runpodctl/overview](https://docs.runpod.io/runpodctl/overview) fails.

`wget` in PowerShell is an alias for `Invoke-WebRequest`, which has no `-O` parameter. `-O` is an ambiguous prefix of `-OutFile`, `-OutVariable`, `-OutBuffer` and `-OperationTimeoutSeconds`, so PowerShell errors out instead of downloading:

```
Parameter cannot be processed because the parameter name 'O' is ambiguous.
```

The snippet was also fenced as `bash` while containing a PowerShell command.

## What changed

- Uses `Invoke-WebRequest` with the full `-OutFile` name, which works on both Windows PowerShell 5.1 and PowerShell 7+ (7 removed the `wget` alias entirely).
- Installs to `%LOCALAPPDATA%\runpodctl` and adds it to `PATH`, so Windows users get a working `runpodctl` command like the macOS and Linux tabs already provide. The old snippet dropped a bare exe in the current directory, so you had to `cd` there and type `.\runpodctl.exe`.
- Adds the ARM64 variant, matching how the Linux tab lists both architectures.

Verified both release zips contain `runpodctl.exe` at the root, so the `-DestinationPath` and `PATH` entry are correct.

Reads the User `PATH` rather than `$env:Path`: the latter is the process `PATH` and includes the machine entries, so writing it back into the user variable would copy the system `PATH` into it permanently. The `-notlike` guard keeps a re-run from appending a duplicate, and `-UseBasicParsing` avoids the "internet explorer engine is not available" failure on fresh Windows PowerShell 5.1 installs.

Not verified on Windows — I have no Windows machine or CI runner. The syntax matches the install guide already shipped in the runpodctl skill.

---

## Related PRs

Two independent groups. Nothing in one blocks anything in the other.

### Group A — the Windows install command (runpod/runpodctl#311)

One broken command that had been copy-pasted into three repos. Each PR fixes its own copy; **any order, no dependencies.**

| PR | Repo | Change |
|---|---|---|
| runpod/runpodctl#328 | runpodctl | `README.md` — fix the command, and install to `PATH` |
| runpod/docs#805 ← **this PR** | docs | `runpodctl/overview.mdx` — same fix on docs.runpod.io |
| runpod/runpod-plugins-official#49 | plugins | delete `reference/install.md`, the third copy |

### Group B — secure registry passwords (runpod/runpodctl#327)

**Order matters.** #51 documents a flag that does not exist on `main` until #329 merges, so it stays draft until then.

| # | PR | Repo | Change |
|---|---|---|---|
| 1 | runpod/runpodctl#329 | runpodctl | `--password-stdin`, no-echo prompt, mutually exclusive flags |
| 2 | runpod/runpod-plugins-official#51 | plugins | skill guidance + regression eval (**draft** until #329 lands) |

The only thing the two groups share is that both touched the runpodctl skill, which is what prompted Group A's deletion: the skill had been keeping its own copy of install instructions the runpodctl README already owned.