### PR TITLE
Fix stale internal documentation links

### DIFF
--- a/instant-clusters/ray-vllm.mdx
+++ b/instant-clusters/ray-vllm.mdx
@@ -228,7 +228,7 @@ If you restart a pod, Ray does not automatically rejoin the cluster. Rerun `head
 
 ## Next steps
 
-- Adapt the serve script to load your own model from a [GlobalStore](/storage/globalstore) or [Network Volume](/storage/network-volumes) mount.
+- Adapt the serve script to load your own model from a [Network Volume](/storage/network-volumes) mount.
 - Scale up by increasing the pod count and adjusting `--pipeline-parallel-size` accordingly.
 - Try [Axolotl on an Instant Cluster](/instant-clusters/axolotl) for distributed fine-tuning.
 - Review the [Instant Cluster configuration reference](/instant-clusters/configuration) for full details on environment variables and networking.

--- a/serverless/advanced-workflows/batch-jobs.mdx
+++ b/serverless/advanced-workflows/batch-jobs.mdx
@@ -174,7 +174,7 @@ The results are paginated. Pass the `offset` and `limit` query parameters to pag
 | `POST` | `/v2/{endpoint_id}/batch/{id}/cancel` | Cancel a batch |
 | `GET` | `/v2/{endpoint_id}/batch/{id}/requests` | Paginated child request list |
 
-For full request and response schemas, see the [API reference](/api-reference/endpoint/batch).
+For full request and response schemas, see the [API reference](#full-api-reference).
 
 ## Monitoring batches in the console
 

--- a/serverless/workers/github-integration.mdx
+++ b/serverless/workers/github-integration.mdx
@@ -33,7 +33,7 @@ For an example repository containing the minimal files necessary for deployment,
 
 Before deploying from GitHub, you need to authorize Runpod to access your repositories:
 
-1. Open the [settings page](http://console.runpod.io/user/settings) in the Runpod console.
+1. Open the [settings page](https://console.runpod.io/user/settings) in the Runpod console.
 
 2. Find the **GitHub** card under **Connections** and click **Connect**.
 


### PR DESCRIPTION
## Summary
- point the Batch API reference link to the existing on-page reference table
- remove the retired GlobalStore destination from the Ray and vLLM guide
- use HTTPS for the Runpod console settings link

## Verification
- `git diff --check`
- `node scripts/validate-tooltips.js`
- `node scripts/validate-redirect-sources.js`
- targeted Vale run, with only pre-existing file-wide findings outside the changed lines