### PR TITLE
docs(runpodctl): drop --stop-after and --terminate-after

### DIFF
--- a/runpodctl/reference/runpodctl-pod.mdx
+++ b/runpodctl/reference/runpodctl-pod.mdx
@@ -184,14 +184,6 @@ Container registry authentication ID for pulling private images. Use [`runpodctl
 Country code for regional deployment (e.g., `US`, `CA`, `EU`). Restricts Pod placement to machines in the specified region.
 </ResponseField>
 
-<ResponseField name="--stop-after" type="string">
-Automatically stop the Pod after a duration (e.g., `1h`, `24h`, `7d`) or at an RFC 3339 timestamp (e.g., `2026-04-15T00:00:00Z`). GPU Pods only.
-</ResponseField>
-
-<ResponseField name="--terminate-after" type="string">
-Automatically terminate the Pod after a duration (e.g., `1h`, `24h`, `7d`) or at an RFC 3339 timestamp (e.g., `2026-04-15T00:00:00Z`). Unlike `--stop-after`, this permanently deletes the Pod. GPU Pods only.
-</ResponseField>
-
 <ResponseField name="--compliance" type="string">
 Compliance settings for the Pod (e.g., regulatory requirements for data handling).
 </ResponseField>

--- a/runpodctl/reference/runpodctl-pod.mdx
+++ b/runpodctl/reference/runpodctl-pod.mdx
@@ -185,11 +185,11 @@ Country code for regional deployment (e.g., `US`, `CA`, `EU`). Restricts Pod pla
 </ResponseField>
 
 <ResponseField name="--stop-after" type="string">
-Automatically stop the Pod after the specified duration (e.g., `1h`, `24h`, `7d`).
+Automatically stop the Pod after a duration (e.g., `1h`, `24h`, `7d`) or at an RFC 3339 timestamp (e.g., `2026-04-15T00:00:00Z`). GPU Pods only.
 </ResponseField>
 
 <ResponseField name="--terminate-after" type="string">
-Automatically terminate the Pod after the specified duration (e.g., `1h`, `24h`, `7d`). Unlike `--stop-after`, this permanently deletes the Pod.
+Automatically terminate the Pod after a duration (e.g., `1h`, `24h`, `7d`) or at an RFC 3339 timestamp (e.g., `2026-04-15T00:00:00Z`). Unlike `--stop-after`, this permanently deletes the Pod. GPU Pods only.
 </ResponseField>
 
 <ResponseField name="--compliance" type="string">


### PR DESCRIPTION
Follows runpod/runpodctl#330, which removes both flags.

They never worked. The timer was accepted, stored on no code path, and acted on by nothing — pods ran past the deadline and kept billing (CON-1258, customer refund). Documenting them as working is what led people to rely on them.

Removing the entries rather than correcting them, to match the remove-first plan: runpodctl#331 restores the flags with client-side validation, and runpod/RunPod#5718 makes the backend actually enforce the deadline. The docs go back when those land.

Also worth noting the entries were wrong on their own terms: they advertised durations (`1h`, `24h`, `7d`), which the GraphQL `DateTime` scalar rejects.