### PR TITLE
Fix GraphQL navigation redirect

### DIFF
--- a/references/graphql-spec.mdx
+++ b/references/graphql-spec.mdx
@@ -1,4 +1,11 @@
 ---
 title: "GraphQL Spec"
-url: "https://graphql-spec.runpod.io/"
+sidebarTitle: "GraphQL Spec"
+description: "Open the Runpod GraphQL schema reference for queries, mutations, fields, and inputs."
 ---
+
+Use the GraphQL schema reference to explore every available query, mutation, field, and input.
+
+<Card title="Open the GraphQL schema reference" href="https://graphql-spec.runpod.io/" icon="code" horizontal>
+  Browse the complete schema on the Runpod GraphQL reference site.
+</Card>


### PR DESCRIPTION
## Summary

- replace the redirect-only GraphQL Spec navigation page with a real docs page
- keep the external schema reference one click away
- remove the internal 307 hop reported by Ahrefs

## Verification

- mint validate: passed
- JSON parse: passed
- tooltip validation: passed
- git diff --check: passed
- mint broken-links: 29 pre-existing issues in 20 unrelated files
- mint a11y: 22 pre-existing issues in 18 unrelated files plus the existing color contrast failure

No production deployment or merge was performed.