### PR TITLE
fix(docs): exclude internal authoring files from publishing

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,0 +1,5 @@
+# Internal authoring guidance is not public product documentation.
+CLAUDE.md
+
+# Coding-agent test definitions and helpers are repository infrastructure.
+tests/


### PR DESCRIPTION
## Problem

The 2026-09-01 focused Ahrefs crawl found that repository-only authoring files are published and indexed as product documentation:

- `/CLAUDE` is a 200 page in the sitemap and links to four ignored `.claude/*.md` files that return 404.
- `/tests/TESTS` is a 200 page in the sitemap even though the `tests/` tree is an internal agent-test harness.

These surfaces account for two orphan-page errors, four 404 URLs, one page-with-broken-links error, and duplicate-H1 noise.

## Change

Add a root `.mintignore` that excludes `CLAUDE.md` and `tests/` from Mintlify processing and publishing. Product documentation, navigation, redirects, and indexing policy are unchanged.

## Verification

- `npx -y mint@latest validate`: passed
- `npx -y mint@latest broken-links`: no broken links
- `node scripts/validate-redirect-sources.js`: 294 redirects valid
- `node scripts/validate-tooltips.js`: passed, with four pre-existing unused-import warnings
- `python3 -m json.tool docs.json`: passed
- `git diff --check`: passed

Production is unchanged. After merge and deployment, verify both excluded URLs are absent and rerun Ahrefs project 10306732.