### PR TITLE
fix(docs): add missing page descriptions

### DIFF
--- a/api-reference-v2/openapi.json
+++ b/api-reference-v2/openapi.json
@@ -8415,6 +8415,7 @@
       "get": {
         "operationId": "listDelegations",
         "summary": "List all ECR delegations",
+        "description": "Returns every AWS ECR delegation owned by the authenticated user, including repository, image tag, AWS region, and registry URI details.",
         "tags": [
           "Registries"
         ],
@@ -8463,6 +8464,7 @@
       "post": {
         "operationId": "createDelegation",
         "summary": "Register an ECR delegation",
+        "description": "Creates an AWS ECR delegation for the specified repository ARN so Runpod can access images from the delegated private repository.",
         "tags": [
           "Registries"
         ],
@@ -8534,6 +8536,7 @@
       "delete": {
         "operationId": "revokeDelegation",
         "summary": "Revoke an ECR delegation",
+        "description": "Revokes an AWS ECR delegation by ID, removing Runpod access to images from the associated private repository and returning no response body.",
         "tags": [
           "Registries"
         ],

--- a/containers.mdx
+++ b/containers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Containers"
+description: "Explore Runpod container tutorials for Dockerfiles, persistence, common Docker commands, application packaging, and Serverless deployment."
 ---
 
 <Card href="/tutorials/introduction/containers" horizontal>

--- a/flash/cli/app.mdx
+++ b/flash/cli/app.mdx
@@ -1,6 +1,7 @@
 ---
 title: "app"
 sidebarTitle: "app"
+description: "Create, inspect, list, and delete Flash applications that organize deployment environments, build artifacts, and configuration."
 ---
 
 Manage Flash applications. An app is the top-level container that groups your deployment environments, build artifacts, and configuration.

--- a/flash/cli/build.mdx
+++ b/flash/cli/build.mdx
@@ -1,6 +1,7 @@
 ---
 title: "build"
 sidebarTitle: "build"
+description: "Build a deployment-ready Flash application artifact without deploying, with controls for dependencies, exclusions, and output files."
 ---
 
 Build a deployment-ready artifact for your Flash application without deploying. Use this for more control over the build process or to inspect the artifact before deploying.

--- a/flash/cli/deploy.mdx
+++ b/flash/cli/deploy.mdx
@@ -1,6 +1,7 @@
 ---
 title: "deploy"
 sidebarTitle: "deploy"
+description: "Build and deploy a Flash application to Runpod Serverless, select an environment, preview the build, and control packaged dependencies."
 ---
 
 Build and deploy your Flash application to Runpod Serverless endpoints in one step. This is the primary command for getting your application running in the cloud.

--- a/flash/cli/dev.mdx
+++ b/flash/cli/dev.mdx
@@ -1,6 +1,7 @@
 ---
 title: "dev"
 sidebarTitle: "dev"
+description: "Run a local Flash development server, test Endpoint functions on Runpod Serverless, and configure provisioning, ports, and updates."
 ---
 
 Start the Flash development server for local testing with automatic updates. A local development server provides a unified interface for testing while `@Endpoint` functions execute on Runpod Serverless.

--- a/flash/cli/env.mdx
+++ b/flash/cli/env.mdx
@@ -1,6 +1,7 @@
 ---
 title: "env"
 sidebarTitle: "env"
+description: "Create, inspect, list, and delete isolated Flash deployment environments for development, staging, and production applications."
 ---
 
 Manage deployment environments for Flash applications. Environments are isolated deployment contexts (like `dev`, `staging`, `production`) within a Flash app.

--- a/flash/cli/init.mdx
+++ b/flash/cli/init.mdx
@@ -1,6 +1,7 @@
 ---
 title: "init"
 sidebarTitle: "init"
+description: "Initialize a Flash project with a FastAPI server, example GPU and CPU workers, configuration files, and a ready-to-run directory structure."
 ---
 
 Create a new Flash project with a ready-to-use template structure including a FastAPI server, example GPU and CPU workers, and configuration files.

--- a/flash/cli/login.mdx
+++ b/flash/cli/login.mdx
@@ -1,6 +1,7 @@
 ---
 title: "login"
 sidebarTitle: "login"
+description: "Authenticate the Flash CLI with Runpod, save your API key locally, and configure browser-based authorization options and timeouts."
 ---
 
 Authenticate with Runpod and save your API key for all Flash operations, including CLI commands and standalone `@Endpoint` functions.

--- a/flash/cli/undeploy.mdx
+++ b/flash/cli/undeploy.mdx
@@ -1,6 +1,7 @@
 ---
 title: "undeploy"
 sidebarTitle: "undeploy"
+description: "List or delete Runpod Serverless endpoints created by Flash, including individual deployments and local development resources."
 ---
 
 Manage and delete Runpod Serverless endpoints deployed via Flash. Use this command to clean up endpoints created during local development with `flash dev`.

--- a/flash/cli/update.mdx
+++ b/flash/cli/update.mdx
@@ -1,6 +1,7 @@
 ---
 title: "update"
 sidebarTitle: "update"
+description: "Update the Flash CLI to the latest or a selected version, understand automatic update checks, and configure when those checks run."
 ---
 
 Update the Flash CLI to the latest version or a specific version. The command fetches version information from PyPI and installs using uv (when available) or pip.

--- a/instant-clusters/axolotl.mdx
+++ b/instant-clusters/axolotl.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Deploy an Instant Cluster with Axolotl"
 sidebarTitle: "Axolotl"
+description: "Deploy a Runpod Cluster with Axolotl and configure multi-GPU distributed training for fine-tuning large language models."
 ---
 import { TrainingTooltip, InferenceTooltip } from "/snippets/tooltips.jsx";
 

--- a/instant-clusters/pytorch.mdx
+++ b/instant-clusters/pytorch.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Deploy an Instant Cluster with PyTorch"
 sidebarTitle: "PyTorch"
+description: "Deploy a Runpod Cluster with PyTorch and configure distributed processing across multiple Pods for multi-GPU workloads."
 ---
 
 import { PyTorchTooltip } from "/snippets/tooltips.jsx";

--- a/instant-clusters/slurm.mdx
+++ b/instant-clusters/slurm.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Deploy an Instant Cluster with Slurm (unmanaged)"
 sidebarTitle: "Slurm (unmanaged)"
+description: "Deploy and configure an unmanaged Runpod Cluster with Slurm to schedule distributed workloads across multiple GPU nodes."
 ---
 
 import { SlurmTooltip } from "/snippets/tooltips.jsx";

--- a/pods/troubleshooting/jupyterlab-checkpoints-folder.mdx
+++ b/pods/troubleshooting/jupyterlab-checkpoints-folder.mdx
@@ -1,6 +1,7 @@
 ---
 title: "JupyterLab checkpoints folder access"
 sidebarTitle: "JupyterLab checkpoints folder"
+description: "Access folders named checkpoints in JupyterLab by renaming them, moving files through the interface, or using terminal commands."
 ---
 
 If you're unable to open a folder named "checkpoints" in JupyterLab, this is a known issue where JupyterLab treats "checkpoints" as a reserved keyword.

--- a/pods/troubleshooting/storage-full.mdx
+++ b/pods/troubleshooting/storage-full.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Storage full"
+description: "Diagnose and resolve storage-full errors on Runpod Pods by checking disk usage, locating large files, and managing container or volume storage."
 ---
 
 Storage full errors can occur when users generate many files, transfer files, or perform other storage-intensive tasks. This document provides guidance to help you troubleshoot this.

--- a/pods/troubleshooting/token-authentication-enabled.mdx
+++ b/pods/troubleshooting/token-authentication-enabled.mdx
@@ -1,5 +1,6 @@
 ---
 title: "JupyterLab server token authentication"
+description: "Recover the JupyterLab server token from a Runpod Pod terminal, then use it to authenticate when the JupyterLab login screen appears."
 ---
 
 If you see a "Token authentication is enabled" screen when trying to access your Pod's JupyterLab server, follow the steps below to log in.

--- a/pods/troubleshooting/troubleshooting-502-errors.mdx
+++ b/pods/troubleshooting/troubleshooting-502-errors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "502 errors"
+description: "Troubleshoot 502 errors on Runpod Pods by checking GPU attachment, application status, port configuration, logs, and template requirements."
 ---
 
 502 errors can occur when users attempt to access a program running on a specific port of a deployed Pod and the program isn't running or has encountered an error. This document provides guidance to help you troubleshoot this error.

--- a/references/cpu-types.mdx
+++ b/references/cpu-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: CPU types
+description: "Review the CPU models available on Runpod, including core counts and threads per core, to compare compute options for your workload."
 ---
 
 The following list contains all CPU types available on Runpod.

--- a/references/video-resources.mdx
+++ b/references/video-resources.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Video resources"
+description: "Browse community video tutorials covering Runpod setup, Stable Diffusion, text generation, file transfer, SSH, and Linux tools."
 ---
 
 ## Runpod Usage

--- a/runpodctl/reference/runpodctl-billing.mdx
+++ b/runpodctl/reference/runpodctl-billing.mdx
@@ -1,6 +1,7 @@
 ---
 title: "billing"
 sidebarTitle: "billing"
+description: "Use runpodctl to retrieve billing history for Pods, Serverless endpoints, and network volumes across configurable time ranges."
 ---
 
 View billing history for Pods, Serverless endpoints, and network volumes.

--- a/runpodctl/reference/runpodctl-config.mdx
+++ b/runpodctl/reference/runpodctl-config.mdx
@@ -1,6 +1,7 @@
 ---
 title: "config"
 sidebarTitle: "config"
+description: "Configure runpodctl with your Runpod API key and API endpoint URL so the CLI can authenticate and manage account resources."
 ---
 
 Configure the Runpod CLI with your API credentials and API URL to enable programmatic access to your Runpod resources.

--- a/runpodctl/reference/runpodctl-datacenter.mdx
+++ b/runpodctl/reference/runpodctl-datacenter.mdx
@@ -1,6 +1,7 @@
 ---
 title: "datacenter"
 sidebarTitle: "datacenter"
+description: "Use runpodctl to list Runpod data centers, review their locations, and inspect current GPU availability from the command line."
 ---
 
 List available datacenters and their locations.

--- a/runpodctl/reference/runpodctl-doctor.mdx
+++ b/runpodctl/reference/runpodctl-doctor.mdx
@@ -1,6 +1,7 @@
 ---
 title: "doctor"
 sidebarTitle: "doctor"
+description: "Run runpodctl doctor to configure API and SSH credentials, verify the CLI setup, and diagnose common connection or configuration problems."
 ---
 
 Diagnose and fix CLI issues, including first-time setup for API keys and SSH configuration.

--- a/runpodctl/reference/runpodctl-gpu.mdx
+++ b/runpodctl/reference/runpodctl-gpu.mdx
@@ -1,6 +1,7 @@
 ---
 title: "gpu"
 sidebarTitle: "gpu"
+description: "Use runpodctl to list available GPU types, include unavailable options, and review hardware specifications from the command line."
 ---
 
 List available GPU types and their specifications.

--- a/runpodctl/reference/runpodctl-hub.mdx
+++ b/runpodctl/reference/runpodctl-hub.mdx
@@ -1,6 +1,7 @@
 ---
 title: "hub"
 sidebarTitle: "hub"
+description: "Browse and search Runpod Hub repos with runpodctl, inspect repository details, and use Hub IDs to deploy Serverless endpoints."
 ---
 
 Browse and search the Runpod Hub marketplace to discover deployable repos. You can list popular repos, search by name, and get details for specific repos. Use Hub repo IDs with [`runpodctl serverless create --hub-id`](/runpodctl/reference/runpodctl-serverless) to deploy endpoints directly from the Hub.

--- a/runpodctl/reference/runpodctl-network-volume.mdx
+++ b/runpodctl/reference/runpodctl-network-volume.mdx
@@ -1,6 +1,7 @@
 ---
 title: "network-volume"
 sidebarTitle: "network-volume"
+description: "Use runpodctl to create, inspect, list, update, and remove persistent network volumes shared by Pods and Serverless endpoints."
 ---
 
 Manage network volumes for persistent shared storage across Pods and Serverless endpoints.

--- a/runpodctl/reference/runpodctl-pod.mdx
+++ b/runpodctl/reference/runpodctl-pod.mdx
@@ -1,6 +1,7 @@
 ---
 title: "pod"
 sidebarTitle: "pod"
+description: "Use runpodctl to create, list, start, stop, inspect, and delete Pods from the command line with status and resource filters."
 ---
 
 Manage Pods, including creating, listing, starting, stopping, and deleting Pods.

--- a/runpodctl/reference/runpodctl-receive.mdx
+++ b/runpodctl/reference/runpodctl-receive.mdx
@@ -1,6 +1,7 @@
 ---
 title: "receive"
 sidebarTitle: "receive"
+description: "Receive files or folders through runpodctl using a secure peer-to-peer connection code shared by the sending machine."
 ---
 
 Receive files or folders sent from another machine using a secure peer-to-peer connection established with a connection code.

--- a/runpodctl/reference/runpodctl-registry.mdx
+++ b/runpodctl/reference/runpodctl-registry.mdx
@@ -1,6 +1,7 @@
 ---
 title: "registry"
 sidebarTitle: "registry"
+description: "Use runpodctl to list, inspect, create, update, and remove credentials for private container registries used by Runpod workloads."
 ---
 
 Manage container registry authentications for private Docker images.

--- a/runpodctl/reference/runpodctl-send.mdx
+++ b/runpodctl/reference/runpodctl-send.mdx
@@ -1,6 +1,7 @@
 ---
 title: "send"
 sidebarTitle: "send"
+description: "Send files or folders from your machine to a Pod or another computer through runpodctl using a secure peer-to-peer connection."
 ---
 
 Transfer files or folders from your local machine to a Pod or another computer using a secure peer-to-peer connection.

--- a/runpodctl/reference/runpodctl-serverless.mdx
+++ b/runpodctl/reference/runpodctl-serverless.mdx
@@ -1,6 +1,7 @@
 ---
 title: "serverless"
 sidebarTitle: "serverless"
+description: "Use runpodctl to create, list, inspect, update, and delete Serverless endpoints, including Hub-based deployments and templates."
 ---
 
 import { VolumeDiskTooltip } from "/snippets/tooltips.jsx";

--- a/runpodctl/reference/runpodctl-ssh.mdx
+++ b/runpodctl/reference/runpodctl-ssh.mdx
@@ -1,6 +1,7 @@
 ---
 title: "ssh"
 sidebarTitle: "ssh"
+description: "Use runpodctl to manage SSH keys and retrieve the connection command and key details required to access a Runpod Pod."
 ---
 
 Manage SSH keys and get SSH connection information for Pods.

--- a/runpodctl/reference/runpodctl-template.mdx
+++ b/runpodctl/reference/runpodctl-template.mdx
@@ -1,6 +1,7 @@
 ---
 title: "template"
 sidebarTitle: "template"
+description: "Use runpodctl to list, search, inspect, create, update, and delete reusable templates for Pods and Serverless endpoints."
 ---
 
 import { VolumeDiskTooltip } from "/snippets/tooltips.jsx";

--- a/runpodctl/reference/runpodctl-update.mdx
+++ b/runpodctl/reference/runpodctl-update.mdx
@@ -1,6 +1,7 @@
 ---
 title: "update"
 sidebarTitle: "update"
+description: "Update runpodctl to the latest release, verify the downloaded binary with its SHA-256 checksum, and confirm the installed version."
 ---
 
 Update `runpodctl` to the latest version to access new features and bug fixes.

--- a/runpodctl/reference/runpodctl-user.mdx
+++ b/runpodctl/reference/runpodctl-user.mdx
@@ -1,6 +1,7 @@
 ---
 title: "user"
 sidebarTitle: "user"
+description: "Use runpodctl to view your Runpod account email, credit balance, hourly spend, spending limit, and notification settings."
 ---
 
 View your account information and current balance.

--- a/runpodctl/reference/runpodctl-version.mdx
+++ b/runpodctl/reference/runpodctl-version.mdx
@@ -1,6 +1,7 @@
 ---
 title: "version"
 sidebarTitle: "version"
+description: "Use runpodctl to display the currently installed CLI version and confirm that an installation or update completed successfully."
 ---
 
 Display the current version of `runpodctl` installed on your system.

--- a/tips-and-tricks/tmux.mdx
+++ b/tips-and-tricks/tmux.mdx
@@ -2,6 +2,7 @@
 title: "Using TMUX for persistent sessions"
 sidebarTitle: "Persistent sessions with TMUX"
 icon: "square-terminal"
+description: "Use TMUX on a Runpod Pod to keep terminal sessions and long-running workloads active through disconnects or JupyterLab interruptions."
 ---
 
 TMUX is a terminal multiplexer that creates persistent terminal sessions on your Pod.


### PR DESCRIPTION
## Summary

- add unique, intent-led descriptions to all 40 pages flagged by the latest Ahrefs Docs crawl
- source 37 descriptions from MDX frontmatter and 3 generated API descriptions from the v2 OpenAPI specification
- preserve headings because all 7 pages flagged for missing H1 return 200 and render exactly one live H1

## Verification

- `python3 -m json.tool docs.json`
- `python3 -m json.tool api-reference-v2/openapi.json`
- `npx -y mint@latest validate`
- `npx -y mint@latest broken-links`
- `node scripts/validate-redirect-sources.js`
- `node scripts/validate-tooltips.js` (passes with 4 pre-existing unused-import warnings)
- `git diff --check`
- all 40 descriptions are 117 to 143 characters
- all 7 Ahrefs H1 URLs return 200 with exactly one rendered H1

## Ahrefs scope

Project: `10306732`
Latest crawl: `2026-09-01T16:06:20Z`
Target issue: 40 indexable pages with a missing or empty meta description.