### PR TITLE
fix(docs): normalize page description lengths

### DIFF
--- a/api-reference-v2/account/list-registered-ssh-public-keys.mdx
+++ b/api-reference-v2/account/list-registered-ssh-public-keys.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/account/ssh-keys
+description: "List the SSH public keys registered to your Runpod account and used to authenticate secure connections to newly created Pods."
 ---

--- a/api-reference-v2/account/replace-registered-ssh-public-keys.mdx
+++ b/api-reference-v2/account/replace-registered-ssh-public-keys.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: put /v2/account/ssh-keys
+description: "Replace all SSH public keys registered to your Runpod account, remove omitted keys, and apply the new set to subsequently created Pods."
 ---

--- a/api-reference-v2/billing/get-aggregated-billing-history.mdx
+++ b/api-reference-v2/billing/get-aggregated-billing-history.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/billing
+description: "Retrieve time-bucketed total Runpod spend across Pods, Serverless, storage, Public Endpoints, and Clusters for the authenticated account."
 ---

--- a/api-reference-v2/billing/get-cluster-billing-history.mdx
+++ b/api-reference-v2/billing/get-cluster-billing-history.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/billing/clusters
+description: "Retrieve time-bucketed Runpod Cluster billing history, including GPU compute, disk, inter-node networking, and total costs."
 ---

--- a/api-reference-v2/billing/get-network-volume-billing-history.mdx
+++ b/api-reference-v2/billing/get-network-volume-billing-history.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/billing/network-volumes
+description: "Retrieve time-bucketed billing history for one or all Runpod network volumes, including storage tiers, totals, and query metadata."
 ---

--- a/api-reference-v2/billing/get-pod-billing-history.mdx
+++ b/api-reference-v2/billing/get-pod-billing-history.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/billing/pods
+description: "Retrieve time-bucketed billing details for one or all Runpod Pods, including GPU, CPU, disk, total costs, and query metadata."
 ---

--- a/api-reference-v2/billing/get-public-endpoint-billing-history.mdx
+++ b/api-reference-v2/billing/get-public-endpoint-billing-history.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/billing/endpoints
+description: "Retrieve time-bucketed billing history for Runpod Public Endpoints, including endpoint totals and resolved query metadata."
 ---

--- a/api-reference-v2/billing/get-serverless-billing-history.mdx
+++ b/api-reference-v2/billing/get-serverless-billing-history.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/billing/serverless
+description: "Retrieve time-bucketed billing history for one or all Runpod Serverless endpoints, including compute, disk, platform, and total costs."
 ---

--- a/api-reference-v2/catalog/get-a-cpu-type.mdx
+++ b/api-reference-v2/catalog/get-a-cpu-type.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/catalog/cpus/{id}
+description: "Retrieve one Runpod CPU type with pricing and optional availability details for a specified product and deployment context."
 ---

--- a/api-reference-v2/catalog/get-a-gpu-type.mdx
+++ b/api-reference-v2/catalog/get-a-gpu-type.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/catalog/gpus/{id}
+description: "Retrieve one Runpod GPU type with pricing and optional availability details for a specified product and deployment context."
 ---

--- a/api-reference-v2/catalog/list-cpu-types.mdx
+++ b/api-reference-v2/catalog/list-cpu-types.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/catalog/cpus
+description: "List available Runpod CPU types with pricing and optional availability details for a specified product and deployment context."
 ---

--- a/api-reference-v2/catalog/list-data-centers.mdx
+++ b/api-reference-v2/catalog/list-data-centers.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/catalog/datacenters
+description: "List Runpod data centers with region, compliance, storage, networking, and optional GPU or CPU availability details."
 ---

--- a/api-reference-v2/catalog/list-gpu-types.mdx
+++ b/api-reference-v2/catalog/list-gpu-types.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/catalog/gpus
+description: "List available Runpod GPU types with pricing and optional availability filters by product, country, and deployment context."
 ---

--- a/api-reference-v2/catalog/list-public-templates.mdx
+++ b/api-reference-v2/catalog/list-public-templates.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/catalog/templates
+description: "List Runpod public templates by official, verified, or community source and inspect reusable Pod and Serverless configurations."
 ---

--- a/api-reference-v2/clusters/create-a-cluster.mdx
+++ b/api-reference-v2/clusters/create-a-cluster.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /v2/clusters
+description: "Create a multi-node Runpod Cluster with a consistent compute shape and container configuration across every member Pod."
 ---

--- a/api-reference-v2/clusters/delete-a-cluster.mdx
+++ b/api-reference-v2/clusters/delete-a-cluster.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: delete /v2/clusters/{id}
+description: "Permanently delete a Runpod Cluster and terminate all of its member Pods, with the response confirming the deleted Cluster."
 ---

--- a/api-reference-v2/clusters/list-a-clusters-pods.mdx
+++ b/api-reference-v2/clusters/list-a-clusters-pods.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/clusters/{id}/pods
+description: "List every Pod in a Runpod Cluster with each member's complete configuration and status, beyond the aggregate counts in the Cluster summary."
 ---

--- a/api-reference-v2/clusters/list-clusters.mdx
+++ b/api-reference-v2/clusters/list-clusters.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/clusters
+description: "List all Runpod Clusters owned by the authenticated user, including each Cluster's configuration, status, and aggregate Pod counts."
 ---

--- a/api-reference-v2/network-volumes/create-a-network-volume.mdx
+++ b/api-reference-v2/network-volumes/create-a-network-volume.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /v2/network-volumes
+description: "Create a persistent Runpod network volume with a name, size, data center, and storage tier for use by Pods and Serverless workers."
 ---

--- a/api-reference-v2/network-volumes/delete-a-network-volume.mdx
+++ b/api-reference-v2/network-volumes/delete-a-network-volume.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: delete /v2/network-volumes/{id}
+description: "Permanently delete a Runpod network volume, release its persistent storage, and confirm the removed volume in the response."
 ---

--- a/api-reference-v2/network-volumes/get-a-network-volume.mdx
+++ b/api-reference-v2/network-volumes/get-a-network-volume.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/network-volumes/{id}
+description: "Retrieve a Runpod network volume by ID with its name, size, data center, storage tier, and current resource details."
 ---

--- a/api-reference-v2/network-volumes/list-network-volumes.mdx
+++ b/api-reference-v2/network-volumes/list-network-volumes.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/network-volumes
+description: "List all network volumes owned by the authenticated Runpod user, including each volume's size, data center, and storage tier."
 ---

--- a/api-reference-v2/overview.mdx
+++ b/api-reference-v2/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "API v2"
 sidebarTitle: "Overview"
-description: "Programmatically manage Runpod resources using the API v2."
+description: "Manage Runpod Pods, Serverless endpoints, Clusters, storage, templates, billing, and account resources programmatically with the REST API v2."
 ---
 The Runpod REST API v2 provides programmatic access to your Runpod resources over standard HTTP. Use it to create and manage Pods, query Serverless endpoints, provision storage, and retrieve billing data — without using the console.
 

--- a/api-reference-v2/pods/create-a-pod.mdx
+++ b/api-reference-v2/pods/create-a-pod.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /v2/pods
+description: "Create a Runpod Pod with GPU or CPU compute, container or template settings, storage, networking, and deployment constraints."
 ---

--- a/api-reference-v2/pods/get-a-pod.mdx
+++ b/api-reference-v2/pods/get-a-pod.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/pods/{id}
+description: "Retrieve a Runpod Pod by ID with its compute, container, storage, networking, lifecycle status, and connection details."
 ---

--- a/api-reference-v2/pods/list-pods.mdx
+++ b/api-reference-v2/pods/list-pods.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/pods
+description: "List Pods owned by the authenticated Runpod user, with an option to include member Pods that belong to Runpod Clusters."
 ---

--- a/api-reference-v2/pods/terminate-a-pod.mdx
+++ b/api-reference-v2/pods/terminate-a-pod.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: delete /v2/pods/{id}
+description: "Permanently terminate a Runpod Pod, release its compute, and understand what happens to persistent mounts, network volumes, and Cluster members."
 ---

--- a/api-reference-v2/pods/trigger-a-pod-state-transition.mdx
+++ b/api-reference-v2/pods/trigger-a-pod-state-transition.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /v2/pods/{id}/action
+description: "Start, stop, or restart a Runpod Pod by sending a supported state transition action and retrieving the Pod's updated lifecycle state."
 ---

--- a/api-reference-v2/pods/update-a-pod.mdx
+++ b/api-reference-v2/pods/update-a-pod.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: patch /v2/pods/{id}
+description: "Update selected settings on an existing Runpod Pod while preserving omitted fields, with guidance on mutable fields and restart behavior."
 ---

--- a/api-reference-v2/registries/create-a-container-registry-credential.mdx
+++ b/api-reference-v2/registries/create-a-container-registry-credential.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /v2/registries
+description: "Store credentials for a private container registry in Runpod for authenticated image pulls while keeping the saved secrets write-only."
 ---

--- a/api-reference-v2/registries/delete-a-container-registry-credential.mdx
+++ b/api-reference-v2/registries/delete-a-container-registry-credential.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: delete /v2/registries/{id}
+description: "Delete a Runpod container registry credential by ID and understand how active Pods and templates that reference it are handled."
 ---

--- a/api-reference-v2/registries/get-a-container-registry-credential.mdx
+++ b/api-reference-v2/registries/get-a-container-registry-credential.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/registries/{id}
+description: "Retrieve a Runpod container registry credential by ID while keeping stored usernames and passwords excluded from the response."
 ---

--- a/api-reference-v2/registries/list-container-registries.mdx
+++ b/api-reference-v2/registries/list-container-registries.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/registries
+description: "List all container registry credentials owned by the authenticated Runpod user, with secret usernames and passwords excluded."
 ---

--- a/api-reference-v2/serverless/create-a-serverless-endpoint.mdx
+++ b/api-reference-v2/serverless/create-a-serverless-endpoint.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /v2/serverless
+description: "Create a Runpod Serverless endpoint with GPU or CPU compute, container or template settings, worker limits, and scaling policies."
 ---

--- a/api-reference-v2/serverless/delete-a-serverless-endpoint.mdx
+++ b/api-reference-v2/serverless/delete-a-serverless-endpoint.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: delete /v2/serverless/{id}
+description: "Permanently delete a Runpod Serverless endpoint, terminate its workers, cancel queued and active jobs, and remove its bound template."
 ---

--- a/api-reference-v2/serverless/get-a-serverless-endpoint.mdx
+++ b/api-reference-v2/serverless/get-a-serverless-endpoint.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/serverless/{id}
+description: "Retrieve a Runpod Serverless endpoint by ID with its compute, worker, scaling, container, storage, and current status settings."
 ---

--- a/api-reference-v2/serverless/list-serverless-endpoint-releases.mdx
+++ b/api-reference-v2/serverless/list-serverless-endpoint-releases.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/serverless/{id}/releases
+description: "List a Serverless endpoint's release history, configuration changes, build IDs, and current worker rollout status, newest release first."
 ---

--- a/api-reference-v2/serverless/list-serverless-endpoint-workers.mdx
+++ b/api-reference-v2/serverless/list-serverless-endpoint-workers.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/serverless/{id}/workers
+description: "List active workers for a Runpod Serverless endpoint with worker status, runtime details, and summary counts grouped by status."
 ---

--- a/api-reference-v2/serverless/list-serverless-endpoints.mdx
+++ b/api-reference-v2/serverless/list-serverless-endpoints.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/serverless
+description: "List all Runpod Serverless endpoints owned by the authenticated user, including compute, worker, scaling, and deployment settings."
 ---

--- a/api-reference-v2/serverless/update-a-serverless-endpoint.mdx
+++ b/api-reference-v2/serverless/update-a-serverless-endpoint.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: patch /v2/serverless/{id}
+description: "Update selected settings on a Runpod Serverless endpoint, including compute, workers, scaling, storage, and container configuration."
 ---

--- a/api-reference-v2/templates/create-a-template.mdx
+++ b/api-reference-v2/templates/create-a-template.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /v2/templates
+description: "Create a reusable Runpod template for Pod and Serverless container settings, including images, storage, ports, environment, and mounts."
 ---

--- a/api-reference-v2/templates/delete-a-template.mdx
+++ b/api-reference-v2/templates/delete-a-template.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: delete /v2/templates/{id}
+description: "Permanently delete an owned Runpod template by ID and understand restrictions when Pods or Serverless endpoints still reference it."
 ---

--- a/api-reference-v2/templates/get-a-template.mdx
+++ b/api-reference-v2/templates/get-a-template.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/templates/{id}
+description: "Retrieve the complete configuration of an owned or public Runpod template by ID, including settings used to create Pods and endpoints."
 ---

--- a/api-reference-v2/templates/list-templates.mdx
+++ b/api-reference-v2/templates/list-templates.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v2/templates
+description: "List all reusable Runpod templates owned by the authenticated user, including Pod and Serverless container configuration details."
 ---

--- a/api-reference-v2/templates/update-a-template.mdx
+++ b/api-reference-v2/templates/update-a-template.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: patch /v2/templates/{id}
+description: "Update selected fields on a Runpod template while preserving omitted settings, with ownership rules and behavior for existing resources."
 ---

--- a/api-reference/docs/GET/docs.mdx
+++ b/api-reference/docs/GET/docs.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Documentation Page"
 openapi: GET /docs
+description: "Open Runpod's interactive API documentation to explore available endpoints, request parameters, response schemas, and authentication requirements."
 ---

--- a/get-started/products.mdx
+++ b/get-started/products.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Runpod product overview"
 sidebarTitle: "Product overview"
-description: "Explore Runpod's major offerings and find the right solution for your workload."
+description: "Compare Runpod Pods, Serverless, Clusters, Public Endpoints, and storage options to choose the right infrastructure for your AI workload."
 ---
 
 import { ServerlessTooltip, PodsTooltip, PublicEndpointTooltip, InstantClusterTooltip } from "/snippets/tooltips.jsx";

--- a/instant-clusters/cluster-observability.mdx
+++ b/instant-clusters/cluster-observability.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cluster observability"
 sidebarTitle: "Cluster observability"
-description: "Monitor your training workloads in real time with built-in Grafana dashboards."
+description: "Monitor Runpod Cluster training workloads in real time with built-in Grafana dashboards for GPU, CPU, memory, network, and storage metrics."
 ---
 
 Instant Clusters include a built-in observability engine that streams cluster metrics at 5-second granularity directly to a Grafana dashboard. No configuration is required. Authentication is handled automatically when you launch a cluster.

--- a/instant-clusters/ray-vllm.mdx
+++ b/instant-clusters/ray-vllm.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Deploy an Instant Cluster with Ray and vLLM"
 sidebarTitle: "Ray + vLLM"
-description: "Run distributed inference across multiple nodes using Ray and vLLM on an Instant Cluster."
+description: "Deploy a Runpod Cluster with Ray and vLLM to serve distributed inference across multiple nodes, including setup, networking, and validation."
 tag: BETA
 ---
 

--- a/integrations/n8n-integration.mdx
+++ b/integrations/n8n-integration.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarTitle: n8n
 title: "Integrate Runpod with n8n"
-description: "Deploy a vLLM worker on Runpod and connect it to n8n for AI-powered workflow automation."
+description: "Deploy a vLLM worker on Runpod and connect it to n8n to build AI-powered workflows with authenticated inference requests and reusable automations."
 tag: "NEW"
 ---
 

--- a/public-endpoints/models/moonshot-kimi.mdx
+++ b/public-endpoints/models/moonshot-kimi.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Moonshot Kimi"
 sidebarTitle: "Moonshot Kimi"
-description: "Moonshot's Kimi family of models handles advanced reasoning, chat, and coding, with extended thinking and a visible reasoning trace. See model inputs and outputs on Runpod Public Endpoints."
+description: "Use Moonshot Kimi models for reasoning, chat, and coding through Runpod Public Endpoints, with supported inputs, outputs, and request examples."
 ---
 
 Moonshot's Kimi family of models handles advanced reasoning and chat. It supports extended thinking with a visible reasoning trace before the final answer. A single endpoint serves three variants, each selected by setting the `model` field in the request body.

--- a/references/graphql-spec.mdx
+++ b/references/graphql-spec.mdx
@@ -1,7 +1,7 @@
 ---
 title: "GraphQL Spec"
 sidebarTitle: "GraphQL Spec"
-description: "Open the Runpod GraphQL schema reference for queries, mutations, fields, and inputs."
+description: "Explore the Runpod GraphQL schema reference for available queries, mutations, fields, arguments, inputs, and response types."
 ---
 
 Use the GraphQL schema reference to explore every available query, mutation, field, and input.

--- a/serverless/batch-jobs.mdx
+++ b/serverless/batch-jobs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Batch jobs"
-description: "Submit large collections of inference requests as a single named batch, processed asynchronously."
+description: "Submit large collections of Serverless inference requests as named batch jobs, then monitor asynchronous processing and retrieve results."
 tag: BETA
 ---
 

--- a/serverless/development/fitness-checks.mdx
+++ b/serverless/development/fitness-checks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Fitness checks and preflight checks"
 sidebarTitle: "Fitness checks and preflight checks"
-description: "Validate a Serverless worker's environment at startup before it takes traffic. Fitness checks, also known as preflight checks, run registered checks before a worker begins processing jobs. Review configuration and operations guidance for Runpod Serverless."
+description: "Validate Serverless worker dependencies at startup with custom and automatic fitness checks, failure handling, configuration, and operations guidance."
 ---
 
 Fitness checks validate a worker's environment at startup, before it begins processing jobs. When a worker starts, Runpod runs each registered check in order. If a check fails, the worker logs the error, exits, and is marked unhealthy so Runpod can restart or replace it before any traffic reaches it. This lets you catch problems like a missing GPU, a model that won't load, or absent configuration up front, instead of failing requests one by one in production.

--- a/serverless/endpoints/rolling-releases.mdx
+++ b/serverless/endpoints/rolling-releases.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Rolling releases"
 sidebarTitle: "Rolling releases"
-description: "How Runpod deploys endpoint updates without taking your endpoint offline."
+description: "Understand how Runpod rolls out Serverless endpoint updates without downtime, including worker replacement, version tracking, and rollback behavior."
 ---
 
 When you update an endpoint's Docker image or configuration, Runpod deploys the change as a rolling release. Workers are replaced progressively rather than all at once, so your endpoint continues to handle requests throughout the update.

--- a/tutorials/pods/use-private-ecr-images.mdx
+++ b/tutorials/pods/use-private-ecr-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Use private AWS ECR images"
 sidebarTitle: "Private ECR images"
-description: "Pull container images from private AWS ECR repositories using cross-account delegation."
+description: "Pull private AWS ECR container images into Runpod Pods by configuring cross-account delegation, IAM permissions, and registry authentication."
 ---
 
 import { PodTooltip } from "/snippets/tooltips.jsx";


### PR DESCRIPTION
## Summary

- normalize meta descriptions for the 34 too-long and 22 too-short pages in the latest Ahrefs Docs crawl
- add page-level metadata overrides to 44 OpenAPI MDX wrappers so detailed endpoint documentation remains unchanged
- update 12 standard MDX descriptions
- keep every changed description between 116 and 150 characters

## Validation

- npx -y mint@latest validate
- npx -y mint@latest broken-links
- node scripts/validate-redirect-sources.js
- node scripts/validate-tooltips.js
- python3 -m json.tool docs.json
- git diff --check
- exact target count: 56 changed pages, 56 descriptions in range

## Scope

Metadata only. No page body, navigation, OpenAPI operation description, redirect, or production changes.