### PR TITLE
fix(docs): resolve residual Ahrefs content issues

### DIFF
--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -27,6 +27,8 @@ All requests require a [Runpod API key](/get-started/api-keys) in the request he
 
 Retrieve the complete OpenAPI specification for client generation, request validation, or tooling integration.
 
+See the [interactive API documentation endpoint reference](/api-reference/docs/GET/docs) to open the browser-based reference directly.
+
 <CodeGroup>
 
 ```bash cURL

--- a/community-solutions/copyparty-file-manager/overview.mdx
+++ b/community-solutions/copyparty-file-manager/overview.mdx
@@ -4,7 +4,7 @@ description: "Web-based GUI for easy file browsing, uploading, downloading, and 
 icon: "party-horn"
 ---
 
-# Setting up CopyParty on Runpod
+## Set up CopyParty on Runpod
 
 CopyParty provides a webbased GUI that makes file management simple on Runpod instances. With its intuitive interface, you can browse directories, upload/download files, preview images and videos, and manage your Pod's filesystem without complex command-line operations.
 

--- a/community-solutions/overview.mdx
+++ b/community-solutions/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Introduction"
+title: "Community solutions"
 description: "Community-created tools and solutions by and for Runpod users. Review setup and usage guidance for this Runpod community solution."
 icon: "flask"
 ---

--- a/get-started/connect-to-runpod.mdx
+++ b/get-started/connect-to-runpod.mdx
@@ -7,6 +7,8 @@ import { PodsTooltip, EndpointTooltip, ServerlessTooltip } from "/snippets/toolt
 
 Runpod offers multiple ways to access and manage your compute resources. Choose the method that best fits your workflow:
 
+If you are deciding between Pods, Serverless, Public Endpoints, and Clusters, start with the [Runpod product overview](/get-started/products).
+
 ## Runpod console
 
 The Runpod console provides an intuitive web interface to manage <PodsTooltip /> and <EndpointTooltip />s, access Pod terminals, send endpoint requests, monitor resource usage, and view billing and usage history.
@@ -38,3 +40,7 @@ The Runpod CLI allows you to manage Pods from your terminal, execute code on Pod
 Every Pod comes pre-installed with the `runpodctl` command and includes a Pod-scoped API key for seamless command-line management.
 
 [Learn more about runpodctl →](/runpodctl/overview)
+
+## Coding agents
+
+Use the [agent onboarding guide](/agent-setup) to install Runpod skills and connect the Runpod MCP server to a supported coding agent.

--- a/instant-clusters.mdx
+++ b/instant-clusters.mdx
@@ -28,6 +28,9 @@ Instant Clusters provide fully managed multi-node compute with high-performance 
   <Card title="Axolotl fine-tuning" href="/instant-clusters/axolotl" icon="screwdriver" horizontal>
     Fine-tune LLMs across multiple GPUs.
   </Card>
+  <Card title="Distributed inference with Ray and vLLM" href="/instant-clusters/ray-vllm" icon="network-wired" horizontal>
+    Serve models across multiple nodes with Ray and vLLM.
+  </Card>
 </CardGroup>
 
 ## How it works

--- a/instant-clusters/axolotl.mdx
+++ b/instant-clusters/axolotl.mdx
@@ -106,6 +106,7 @@ You can monitor your cluster usage and spending using the **Billing Explorer** a
 
 Now that you've successfully deployed and tested an Axolotl distributed training job on an Instant Cluster, you can:
 
+* Review the [fine-tuning guide](/fine-tune) for a complete Axolotl workflow and deployment path.
 * **Fine-tune your own models** by modifying the configuration files in Axolotl to suit your specific requirements.
 * **Scale your training** by adjusting the number of Pods in your cluster (and the size of their containers and volumes) to handle larger models or datasets.
 * **Try different optimization techniques** such as DeepSpeed, FSDP (Fully Sharded Data Parallel), or other distributed training strategies.

--- a/serverless/development/local-testing.mdx
+++ b/serverless/development/local-testing.mdx
@@ -3,7 +3,7 @@ title: "Local testing"
 description: "Test your Serverless handlers locally before deploying to production. Review configuration and operations guidance for Runpod Serverless."
 ---
 
-Testing your handler locally before deploying saves time and helps you catch issues early. The Runpod SDK provides multiple ways to test your handler function without consuming cloud resources.
+Testing your handler locally before deploying saves time and helps you catch issues early. The Runpod SDK provides multiple ways to test your handler function without consuming cloud resources. See the [Serverless development overview](/serverless/development/overview) for the complete development lifecycle.
 
 ## Basic testing
 

--- a/serverless/vllm/openai-compatibility.mdx
+++ b/serverless/vllm/openai-compatibility.mdx
@@ -190,3 +190,7 @@ See [environment variables reference](/serverless/vllm/environment-variables) fo
 | Authentication error | Use your Runpod API key, not an OpenAI key. |
 | Timeout errors | Increase client timeout for large models. |
 | Unexpected response format | Set `RAW_OPENAI_OUTPUT=1`. |
+
+## Integrate with workflow tools
+
+Follow the [n8n integration guide](/integrations/n8n-integration) to connect an OpenAI-compatible Runpod endpoint to an automated workflow.

--- a/tutorials/introduction/overview.mdx
+++ b/tutorials/introduction/overview.mdx
@@ -27,6 +27,9 @@ Step-by-step guides for building and deploying example applications on Runpod.
   <Card title="Generate images with ComfyUI" href="/tutorials/serverless/comfyui" icon="images" horizontal>
     Deploy ComfyUI and generate images using JSON workflows.
   </Card>
+  <Card title="Run Ollama on Serverless CPU" href="/tutorials/serverless/run-ollama-inference" icon="microchip" horizontal>
+    Deploy an Ollama server on CPU workers and send an inference request.
+  </Card>
 </CardGroup>
 
 ## Flash
@@ -65,5 +68,16 @@ Step-by-step guides for building and deploying example applications on Runpod.
 <CardGroup cols={3}>
   <Card title="Build a text-to-video pipeline" href="/tutorials/public-endpoints/text-to-video-pipeline" icon="video" horizontal>
     Chain multiple Public Endpoints to generate videos from text.
+  </Card>
+</CardGroup>
+
+## More resources
+
+<CardGroup cols={2}>
+  <Card title="Container tutorials" href="/containers" icon="container-storage" horizontal>
+    Learn container fundamentals, Dockerfile creation, persistence, and common Docker commands.
+  </Card>
+  <Card title="Community video resources" href="/references/video-resources" icon="circle-play" horizontal>
+    Browse community tutorials about Runpod workflows and supporting Linux tools.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- add contextual internal links to the 10 URLs Ahrefs reports as orphaned
- demote the duplicate explicit H1 on the CopyParty guide
- disambiguate the Community solutions hub title from the CopyParty page

## Crawl evidence

Fresh Ahrefs crawl completed 2026-09-02 14:42:43 UTC:
- 416 URLs crawled, health score 95
- meta descriptions too long: 0, down 34
- meta descriptions too short: 0, down 22
- orphan pages: 10, addressed by this PR
- multiple H1 tags: 1, addressed by this PR

The 12 H1-missing, low-word-count, and no-outgoing-link flags are intermittent Ahrefs JavaScript-rendering failures. Raw served HTML for all 12 returns HTTP 200, exactly one H1, and 60 to 114 internal links.

The four remaining long-title URLs are already covered by #761.

## Validation

- Mintlify build validation passed
- Mintlify broken-link validation passed
- 294 redirect sources validated
- tooltip import validation passed
- docs.json parses
- git diff check passed
- Vale has the same two pre-existing errors as main on the touched files