### PR TITLE
fix(docs): clear final Ahrefs crawl issues

### DIFF
--- a/api-reference-v2/openapi.json
+++ b/api-reference-v2/openapi.json
@@ -5568,7 +5568,7 @@
       "get": {
         "operationId": "getPodLogs",
         "summary": "Stream pod logs",
-        "description": "Streams pod logs as Server-Sent Events. The `source` query parameter\nselects which log source to include.\n\nThe SSE `data` payload shape is:\n`{ \"source\": \"container\", \"line\": \"...\", \"ts\": \"...\" }`.\nLog-event `id` values are the event `ts` timestamp so\nbrowser/EventSource reconnects can resume with `Last-Event-ID`.\n",
+        "description": "Stream Pod logs as Server-Sent Events. Choose a log source, receive source, line, and ts fields, and resume using Last-Event-ID.",
         "tags": [
           "Pods"
         ],
@@ -7093,7 +7093,7 @@
       "get": {
         "operationId": "getWorkerLogs",
         "summary": "Stream serverless worker logs",
-        "description": "Streams a serverless worker's logs as Server-Sent Events. The `source`\nquery parameter selects which log source to include.\n\nThe SSE `data` payload shape is:\n`{ \"source\": \"container\", \"line\": \"...\", \"ts\": \"...\" }`.\nLog-event `id` values are the event `ts` timestamp so browser/EventSource\nreconnects can resume with `Last-Event-ID`.\n",
+        "description": "Stream Serverless worker logs as Server-Sent Events. Choose a log source, receive source, line, and ts fields, and resume using Last-Event-ID.",
         "tags": [
           "Serverless"
         ],

--- a/instant-clusters.mdx
+++ b/instant-clusters.mdx
@@ -18,6 +18,8 @@ Instant Clusters provide fully managed multi-node compute with high-performance 
 
 ## Get started
 
+For distributed inference across multiple nodes, follow the [Ray and vLLM deployment guide](/instant-clusters/ray-vllm).
+
 <CardGroup cols={3}>
   <Card title="Deploy a Slurm cluster" href="/instant-clusters/slurm-clusters" icon="splotch" horizontal>
     Managed Slurm for HPC workloads.

--- a/tutorials/introduction/overview.mdx
+++ b/tutorials/introduction/overview.mdx
@@ -11,6 +11,8 @@ Step-by-step guides for building and deploying example applications on Runpod.
 
 ## Serverless
 
+For CPU-based inference, follow the [Ollama Serverless tutorial](/tutorials/serverless/run-ollama-inference).
+
 <CardGroup cols={3}>
   <Card title="Create an image generation endpoint" href="/tutorials/serverless/run-your-first" icon="image" horizontal>
     Deploy a Stable Diffusion endpoint and generate your first AI image.
@@ -72,6 +74,8 @@ Step-by-step guides for building and deploying example applications on Runpod.
 </CardGroup>
 
 ## More resources
+
+Review [container tutorials](/containers) for packaging guidance, or browse [community video resources](/references/video-resources) for additional walkthroughs.
 
 <CardGroup cols={2}>
   <Card title="Container tutorials" href="/containers" icon="container-storage" horizontal>


### PR DESCRIPTION
## Summary

- add raw-HTML contextual links for four pages whose existing links render only through Mintlify Card components
- shorten two API v2 log-stream descriptions to valid meta-description lengths while retaining source, event fields, and resume behavior

## Ahrefs evidence

Final server-rendered crawl completed 2026-09-02 16:59:21 UTC:
- health score: 99, up from 95
- original orphan pages: 10 removed
- multiple H1 tags: 0
- H1 missing, low word count, and no outgoing links: 0 after disabling JavaScript execution
- remaining orphan pages: 4 Card-only links, addressed here
- remaining long meta descriptions: 2 generated API pages, addressed here

## Validation

- Mintlify build validation passed
- Mintlify broken-link validation passed
- OpenAPI and docs.json parse
- 294 redirect sources validated
- tooltip import validation passed
- Vale reports 0 errors on changed MDX files
- git diff check passed

## Overlap

PR #788 also edits api-reference-v2/openapi.json, but at different operations and line ranges. This patch is limited to getPodLogs and getWorkerLogs.