### PR TITLE
Fix four broken external documentation references

### DIFF
--- a/flash/apps/deploy-apps.mdx
+++ b/flash/apps/deploy-apps.mdx
@@ -224,7 +224,7 @@ uv run flash deploy --exclude scipy,pandas
 
 <Tip>
 
-Check the [worker-flash repository](https://github.com/runpod-workers/worker-flash) for current base images and pre-installed packages.
+Check the [Flash worker repository](https://github.com/runpod-workers/flash) for current base images and pre-installed packages.
 
 </Tip>
 

--- a/flash/cli/build.mdx
+++ b/flash/cli/build.mdx
@@ -160,7 +160,7 @@ flash build --exclude scipy,pandas
 
 <Tip>
 
-Check the [worker-flash repository](https://github.com/runpod-workers/worker-flash) for current base images and pre-installed packages.
+Check the [Flash worker repository](https://github.com/runpod-workers/flash) for current base images and pre-installed packages.
 
 </Tip>
 

--- a/tutorials/introduction/containers.mdx
+++ b/tutorials/introduction/containers.mdx
@@ -109,7 +109,7 @@ This tutorial series guides you through container fundamentals in a hands-on way
 
 Ready to get hands-on with Docker? Start with [creating your first Dockerfile](/tutorials/introduction/containers/create-dockerfiles).
 
-For more in-depth container concepts, see Docker's [container concepts documentation](https://docs.docker.com/guides/docker-concepts/).
+For more in-depth container concepts, see Docker's [container concepts documentation](https://docs.docker.com/get-started/docker-concepts/the-basics/what-is-a-container/).
 
 When you're ready to deploy containers on Runpod:
 

--- a/tutorials/serverless/comfyui.mdx
+++ b/tutorials/serverless/comfyui.mdx
@@ -357,7 +357,7 @@ ComfyUI workflows are JSON structures that define the image generation pipeline 
 
 You can create custom workflows by modifying node parameters or [opening the ComfyUI interface in a <PodTooltip />](/tutorials/pods/comfyui) and exporting the workflow to JSON.
 
-To learn more about creating your own ComfyUI workflows, see the [ComfyUI documentation](https://docs.comfy.org/development/core-concepts/workflow).
+To learn more about creating your own ComfyUI workflows, see the [ComfyUI documentation](https://docs.comfy.org/basic-concepts/workflow).
 
 ## Next steps
 


### PR DESCRIPTION
Replaces four broken external references across the Containers and ComfyUI tutorials and two Flash pages. Docker now links directly to its container concept page, ComfyUI to its current workflow concept page, and Flash to the maintained runpod-workers/flash repository whose Dockerfiles define the documented worker images.

Validation: all three destinations return HTTP 200; the Flash image names were compared with SDK constants and worker Dockerfiles. `npx --yes mint@latest validate`, tooltip validation and `git diff --check` pass. Vale reports four pre-existing errors in the unchanged baseline, with no new error introduced by these link edits. No instructions or code examples changed.

Do not merge automatically: merging deploys Docs. All four pages were checked in the local rendered Chrome preview; corrected anchors and headings are present with no horizontal overflow. The Flash deployment page also passed a 375px mobile check. Hosted preview and production remain unverified.

Overlap: #765 touches three of these pages but links Flash to the SDK repository. This PR uses the actual worker-image repository and adds ComfyUI. Preserve #765 for owner review; merge only one resolution of the overlapping links. The documented reviewer muhsinking could not be assigned because GitHub did not resolve that login.
