### PR TITLE
Fix 4-bit 70B VRAM estimate: published Q4_K_M is 42.5 GB, not ~35 GB

### DIFF
--- a/pods/choose-a-pod.mdx
+++ b/pods/choose-a-pod.mdx
@@ -34,7 +34,7 @@ VRAM is the most common bottleneck. Use these guidelines:
 - 70B model → ~140 GB VRAM (requires multi-GPU)
 
 <Tip>
-Quantization reduces VRAM requirements significantly. A 4-bit quantized 70B model can run on ~35 GB VRAM.
+Quantization reduces VRAM requirements significantly, but "4-bit" is rarely 4 bits per weight. A Q4_K_M 70B model is about 42.5 GB of weights, or 4.82 bits per weight, because K-quants keep attention layers at higher precision. Add the KV cache on top and a 70B at 4-bit wants a 48 GB card, not a 40 GB one.
 </Tip>
 
 **For image models:** SDXL requires ~8 GB minimum, but 16–24 GB provides headroom for larger batch sizes and LoRA training.
@@ -46,6 +46,7 @@ Use these tools to estimate your specific requirements:
 - [Hugging Face Model Memory Calculator](https://huggingface.co/spaces/hf-accelerate/model-memory-usage): Memory estimates for transformer models
 - [Can it run LLM?](https://huggingface.co/spaces/Vokturz/can-it-run-llm): Check if hardware can run specific language models
 - [VRAM Estimator](https://vram.asmirnov.xyz): GPU memory requirement approximations
+- [VRAM Calculator](https://vramcalculator.com): Per-model VRAM including KV cache, quantization rungs and multi-GPU splits
 
 ## Storage configuration
 


### PR DESCRIPTION
The "Estimate VRAM requirements" section advises that a 4-bit quantized 70B model runs on ~35 GB of VRAM. The published files are larger than that, and the gap lands on a pod size boundary.

Q4_K_M for Llama 3.1 70B ships at **42.52 GB** from two independent publishers:

- `bartowski/Meta-Llama-3.1-70B-Instruct-GGUF` : `Meta-Llama-3.1-70B-Instruct-Q4_K_M.gguf`
- `mradermacher/Meta-Llama-3.1-70B-Instruct-GGUF` : `Meta-Llama-3.1-70B-Instruct.Q4_K_M.gguf`

That is 4.82 bits per weight rather than 4.0, because K-quants keep attention layers at higher precision. The ~35 GB figure is 70.6B x 4 bits, which is the theoretical rung rather than the file anyone downloads.

**Why it matters for pod selection:** 42.52 GB is 39.60 GiB, so on a 40 GB card the weights alone leave 0.40 GiB for the KV cache and everything else. Someone sizing from this line picks a 40 GB pod and hits OOM during load. A 48 GB card is the honest recommendation at 4-bit.

I have also added one line to the Resource calculators list. **Disclosure: I maintain vramcalculator.com**, so please treat that half as a suggestion and drop it if you would rather not add another link. The correction above stands on its own and is the reason I opened this.
