### PR TITLE
feat: re-enable the Runpod Assistant chat widget

### DIFF
--- a/chat-widget.js
+++ b/chat-widget.js
@@ -1,12 +1,11 @@
 // Runpod Docs Chat Widget
-// Temporarily disabled — uncomment to re-enable the Runpod Assistant widget.
-// const WIDGET_BASE_URL = "https://runpod-assistant-doc-backend.vercel.app";
-//
-// const script = document.createElement("script");
-// script.src = `${WIDGET_BASE_URL}/chat-widget.js`;
-// script.async = true;
-// script.setAttribute("data-api-url", `${WIDGET_BASE_URL}/api`);
-// script.setAttribute("data-title", "Runpod Assistant");
-// script.setAttribute("data-greeting", "Hi! How can I help you with Runpod today?");
-// script.setAttribute("data-primary-color", "#5D29F0");
-// document.head.appendChild(script);
+const WIDGET_BASE_URL = "https://runpod-assistant-doc-backend.vercel.app";
+
+const script = document.createElement("script");
+script.src = `${WIDGET_BASE_URL}/chat-widget.js`;
+script.async = true;
+script.setAttribute("data-api-url", `${WIDGET_BASE_URL}/api`);
+script.setAttribute("data-title", "Runpod Assistant");
+script.setAttribute("data-greeting", "Hi! How can I help you with Runpod today?");
+script.setAttribute("data-primary-color", "#5D29F0");
+document.head.appendChild(script);


### PR DESCRIPTION
Reverts the temporary disable from #762 by uncommenting the widget loader. One file, no config change.

Depends on runpod/runpod-assistant-doc-backend#31 — the docs site loads the bundle from that deployment, so merge this after #31 ships or the old bottom-right pill comes back instead of the new ask bar.

## What the reader gets

A bottom-center `Ask a question…` bar with a ⌘I shortcut, a sparkle launcher next to the sidebar search box, and a right-side Assistant panel that shifts page content rather than covering it.

<details>
<summary>Verification</summary>

Ran `mint dev` against a local doc-backend and assistant; the widget loaded, streamed a real answer, and rendered source cards. The prod `WIDGET_BASE_URL` in this diff is the Vercel deployment, not the localhost URL used for that test.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)